### PR TITLE
Prevent forced Pages production promotion

### DIFF
--- a/.github/workflows/pages-production.yml
+++ b/.github/workflows/pages-production.yml
@@ -124,7 +124,7 @@ jobs:
             --method PATCH \
             "repos/${REPOSITORY}/git/refs/heads/${PAGES_PRODUCTION_BRANCH}" \
             -f sha="${release_sha}" \
-            -F force=true \
+            -F force=false \
             --jq '.object.sha')"
           [ "${updated_sha}" = "${release_sha}" ] || \
             fail "GitHub did not update the production branch to the release SHA"

--- a/scripts/ci/test-release-gates.sh
+++ b/scripts/ci/test-release-gates.sh
@@ -434,7 +434,7 @@ for required_control in (
     "repos/${REPOSITORY}/compare/${release_sha}...master",
     "repos/${REPOSITORY}/compare/${current_sha}...${release_sha}",
     "repos/${REPOSITORY}/git/refs/heads/${PAGES_PRODUCTION_BRANCH}",
-    '-F force=true',
+    '-F force=false',
 ):
     check(required_control in pages_run, f"Pages production step is missing control: {required_control}")
 


### PR DESCRIPTION
## Summary

- update `pages-production` with an explicitly non-force Git ref operation
- preserve the existing ancestry and concurrent-change checks
- assert the non-force operation in the release-gate tests

## Why

The promotion already requires the release SHA to be strictly ahead of the current production ref. Passing `force=false` makes GitHub independently enforce that fast-forward invariant and allows the branch to reject force pushes safely.

## Validation

- `nix develop --no-update-lock-file .#ci -c ./scripts/ci/test-release-gates.sh`
- `nix flake check --no-update-lock-file`
- normal pre-commit hook: formatting, frontend builds, and 768 frontend tests

No release or deployment was triggered.