### PR TITLE
fix(chat): stop retrying exhausted image descriptions

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -179,6 +179,7 @@ import {
   type ChatStreamTerminalState
 } from "@/services/chatStreamDeltaCoalescer";
 import { recoverFailedSendAfterDestinationAdoption } from "@/services/chatSendFailureRecovery";
+import { isImageDescriptionUnavailableError } from "@/services/chatResponseErrors";
 import {
   getRegisteredChatOptimisticMessage,
   markOptimisticMessageIncomplete,
@@ -4826,6 +4827,13 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         const causeMessage = (error as Error & { cause?: { message?: string } })?.cause?.message;
         if (causeMessage && causeMessage.includes("Request failed with status")) {
           errorMessage = causeMessage;
+        }
+
+        if (isImageDescriptionUnavailableError(error)) {
+          restoreOriginComposer(
+            "Image description is temporarily unavailable. Your message and images were restored; please try again."
+          );
+          return;
         }
 
         const parseStatusError = (status: number) => {

--- a/frontend/src/services/chatResponseErrors.test.ts
+++ b/frontend/src/services/chatResponseErrors.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { APIConnectionError } from "openai";
+import { isImageDescriptionUnavailableError } from "./chatResponseErrors";
+
+function codedError(
+  status = 503,
+  contract = "1",
+  code = "image_description_unavailable"
+): Error & { status: number; headers: Headers } {
+  return Object.assign(new Error("Request failed"), {
+    status,
+    headers: new Headers({
+      "x-opensecret-error-contract": contract,
+      "x-opensecret-error-code": code
+    })
+  });
+}
+
+describe("Responses error classification", () => {
+  test("recognizes the coded descriptor failure through the OpenAI connection wrapper", () => {
+    const error = new APIConnectionError({ cause: codedError() });
+
+    expect(isImageDescriptionUnavailableError(error)).toBe(true);
+  });
+
+  test("recognizes a top-level OpenAI-style HTTP error", () => {
+    expect(isImageDescriptionUnavailableError(codedError())).toBe(true);
+  });
+
+  test("fails closed for unrelated or malformed errors", () => {
+    expect(isImageDescriptionUnavailableError(codedError(500))).toBe(false);
+    expect(isImageDescriptionUnavailableError(codedError(503, "2"))).toBe(false);
+    expect(isImageDescriptionUnavailableError(codedError(503, "1", "other_error"))).toBe(false);
+    expect(
+      isImageDescriptionUnavailableError(
+        Object.assign(new Error("missing contract"), {
+          status: 503,
+          headers: new Headers({
+            "x-opensecret-error-code": "image_description_unavailable"
+          })
+        })
+      )
+    ).toBe(false);
+    expect(isImageDescriptionUnavailableError(new Error("ordinary failure"))).toBe(false);
+  });
+});

--- a/frontend/src/services/chatResponseErrors.ts
+++ b/frontend/src/services/chatResponseErrors.ts
@@ -1,0 +1,36 @@
+const ERROR_CONTRACT_HEADER = "x-opensecret-error-contract";
+const ERROR_CODE_HEADER = "x-opensecret-error-code";
+const ERROR_CONTRACT_VERSION = "1";
+const IMAGE_DESCRIPTION_UNAVAILABLE_ERROR_CODE = "image_description_unavailable";
+const IMAGE_DESCRIPTION_UNAVAILABLE_STATUS = 503;
+const MAX_ERROR_CAUSE_DEPTH = 4;
+
+type ErrorResponseMetadata = {
+  status?: unknown;
+  headers?: unknown;
+  cause?: unknown;
+};
+
+export function isImageDescriptionUnavailableError(error: unknown): boolean {
+  const seen = new Set<object>();
+  let current = error;
+
+  for (let depth = 0; depth < MAX_ERROR_CAUSE_DEPTH; depth += 1) {
+    if (typeof current !== "object" || current === null || seen.has(current)) return false;
+    seen.add(current);
+
+    const metadata = current as ErrorResponseMetadata;
+    if (
+      metadata.status === IMAGE_DESCRIPTION_UNAVAILABLE_STATUS &&
+      metadata.headers instanceof Headers &&
+      metadata.headers.get(ERROR_CONTRACT_HEADER) === ERROR_CONTRACT_VERSION &&
+      metadata.headers.get(ERROR_CODE_HEADER) === IMAGE_DESCRIPTION_UNAVAILABLE_ERROR_CODE
+    ) {
+      return true;
+    }
+
+    current = metadata.cause;
+  }
+
+  return false;
+}

--- a/sdk/src/lib/ai.ts
+++ b/sdk/src/lib/ai.ts
@@ -310,7 +310,13 @@ export function createCustomFetchWithDependencies(
           " and message:",
           errorText
         );
-        throw new Error(`Request failed with status ${response.status}: ${errorText}`);
+        throw Object.assign(
+          new Error(`Request failed with status ${response.status}: ${errorText}`),
+          {
+            status: response.status,
+            headers: new Headers(response.headers)
+          }
+        );
       }
 
       // Decrypt SSE events

--- a/sdk/src/lib/test/customFetch.test.ts
+++ b/sdk/src/lib/test/customFetch.test.ts
@@ -1129,6 +1129,40 @@ describe("createCustomFetch stale-session recovery", () => {
     expect(forcedAttestations).toBe(0);
   });
 
+  test("preserves coded application error metadata without replay", async () => {
+    let requests = 0;
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        fetch: async () => {
+          requests += 1;
+          return contractError(
+            503,
+            '{"status":503,"message":"Upstream provider temporarily unavailable"}',
+            "image_description_unavailable"
+          );
+        }
+      })
+    );
+
+    let thrown: unknown;
+    try {
+      await customFetch("https://example.test/v1/responses");
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(requests).toBe(1);
+    expect(thrown).toBeInstanceOf(Error);
+    const requestError = thrown as Error & { status?: number; headers?: Headers };
+    expect(requestError.message).toBe(
+      'Request failed with status 503: {"status":503,"message":"Upstream provider temporarily unavailable"}'
+    );
+    expect(requestError.status).toBe(503);
+    expect(requestError.headers?.get(ERROR_CONTRACT_HEADER)).toBe("1");
+    expect(requestError.headers?.get(ERROR_CODE_HEADER)).toBe("image_description_unavailable");
+  });
+
   test("forwards one endpoint-bound PCR policy through lookup and renewal", async () => {
     const apiUrl = "https://enclave.example.test/base";
     const pcrConfig: PcrConfig = {


### PR DESCRIPTION
## Summary

- preserve OpenSecret HTTP status and response headers on encrypted-fetch failures without changing the existing error message
- recognize only contract-v1 HTTP 503 errors coded image_description_unavailable, including the OpenAI client wrapper shape
- restore the original message and image attachments instead of automatically repeating the full descriptor cascade
- fail closed to existing retry behavior for unrelated, missing, malformed, or future error contracts

## Stack

Stacked on #866 and depends on OpenSecretCloud/opensecret#305, which is itself stacked on OpenSecretCloud/opensecret#304.

Review and merge #866 first; after that, retarget this PR to master if GitHub does not do so automatically. OpenSecret #305 should deploy before this Maple behavior ships.

## Validation

- SDK formatting and build passed
- SDK credential-free suite: 115 passed, 3 hosted tests skipped, 0 failed
- encrypted-fetch focused suite: 31 passed
- Maple frontend typecheck and production build passed
- Maple frontend suite: 771 passed, 0 failed
- error classifier focused suite: 3 passed