### PR TITLE
chore(proxy): bump version to 0.3.4

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "maple-proxy"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1445,7 +1445,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple-proxy"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple-proxy"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["OpenSecret"]
 description = "Lightweight OpenAI-compatible proxy server for Maple/OpenSecret TEE infrastructure"


### PR DESCRIPTION
## Summary

- bump maple-proxy from 0.3.3 to 0.3.4
- update the proxy lockfile package version
- allow the next natural Maple release to publish the changed proxy container to ghcr.io/opensecretcloud/maple-proxy

This is the version-only follow-up to the v3.3.10 GHCR sibling run failing closed because proxy runtime inputs changed without a proxy version bump. This PR does not publish a container or create a release.

## Validation

- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features (27 passed)
- cargo doc --locked --no-deps --all-features with warnings denied
- cargo machete
- nix flake check --no-update-lock-file
- repository pre-commit hook