### PR TITLE
chore: bump Maple to v3.3.11

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "3.3.10",
+  "version": "3.3.11",
   "type": "module",
   "packageManager": "bun@1.3.5",
   "trustedDependencies": [],

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4704,7 +4704,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple"
-version = "3.3.10"
+version = "3.3.11"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "3.3.10"
+version = "3.3.11"
 description = "Maple AI"
 authors = ["tony@trymaple.ai"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.10</string>
+	<string>3.3.11</string>
 	<key>CFBundleVersion</key>
-	<string>3.3.10</string>
+	<string>3.3.11</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -53,8 +53,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 3.3.10
-        CFBundleVersion: 3.3.10
+        CFBundleShortVersionString: 3.3.11
+        CFBundleVersion: 3.3.11
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",
@@ -98,7 +98,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 2000028021
+      "versionCode": 2000028022
     },
     "windows": {
       "certificateThumbprint": null,


### PR DESCRIPTION
## Summary

- bump Maple from 3.3.10 to 3.3.11 using the repository patch-bump helper
- update desktop, frontend, and generated Apple version metadata
- increment Android versionCode from 2000028021 to 2000028022

This PR only prepares the next patch version. It does not create a GitHub release or publish mobile builds.

## Validation

- just get-version (3.3.11)
- cargo check --locked
- nix flake check --no-update-lock-file
- repository pre-commit hook (799 frontend tests and 401 Rust tests passed)