### PR TITLE
feat: self-service Zaprite Pro to Max upgrades

### DIFF
--- a/frontend/src/billing/billingApi.test.ts
+++ b/frontend/src/billing/billingApi.test.ts
@@ -1,5 +1,5 @@
 import { expect, spyOn, test } from "bun:test";
-import { fetchProducts } from "./billingApi";
+import { createZapriteUpgrade, fetchProducts } from "./billingApi";
 
 test("fetchProducts rejects an HTTP error response before parsing it as products", async () => {
   const previousBillingApiUrl = process.env.VITE_MAPLE_BILLING_API_URL;
@@ -22,5 +22,53 @@ test("fetchProducts rejects an HTTP error response before parsing it as products
     }
     fetchSpy.mockRestore();
     consoleErrorSpy.mockRestore();
+  }
+});
+
+test("createZapriteUpgrade rejects a checkout URL from the wrong host", async () => {
+  const previousBillingApiUrl = process.env.VITE_MAPLE_BILLING_API_URL;
+  process.env.VITE_MAPLE_BILLING_API_URL = "https://billing.example.test";
+  const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        upgrade_id: "upgrade-1",
+        status: "PENDING",
+        checkout_url: "https://evil.example/pay",
+        quote: {
+          quote_id: "quote-1",
+          source: { product_id: "pro", plan_name: "Pro", annual_amount_cents: 21600 },
+          target: {
+            product_id: "max",
+            plan_name: "Max",
+            monthly_amount_cents: 10000,
+            annual_amount_cents: 108000,
+            discount_basis_points: 1000
+          },
+          subscription_start: "2026-01-01T00:00:00Z",
+          subscription_end: "2027-01-01T00:00:00Z",
+          quote_effective_at: "2026-09-01T00:00:00Z",
+          period_seconds: 31536000,
+          remaining_seconds: 10000000,
+          amount_due_cents: 80956,
+          currency: "USD",
+          expires_at: "2026-09-01T00:15:00Z"
+        }
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    )
+  );
+
+  try {
+    await expect(
+      createZapriteUpgrade("token", "quote-1", "11111111-1111-1111-1111-111111111111")
+    ).rejects.toThrow("Checkout URL is not from the expected payment provider");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  } finally {
+    if (previousBillingApiUrl === undefined) {
+      delete process.env.VITE_MAPLE_BILLING_API_URL;
+    } else {
+      process.env.VITE_MAPLE_BILLING_API_URL = previousBillingApiUrl;
+    }
+    fetchSpy.mockRestore();
   }
 });

--- a/frontend/src/billing/billingApi.ts
+++ b/frontend/src/billing/billingApi.ts
@@ -1,4 +1,11 @@
 import { isMobile, isTauri } from "@/utils/platform";
+import {
+  isAllowedZapriteCheckoutUrl,
+  parseBillingApiError,
+  type ZapriteUpgradeCreateResponse,
+  type ZapriteUpgradeQuote,
+  type ZapriteUpgradeStatusResponse
+} from "./zapriteUpgrade";
 
 // API Credit Purchase Constants
 export const MIN_PURCHASE_CREDITS = 10000;
@@ -19,6 +26,13 @@ export type BillingStatus = {
   used_tokens: number | null;
   usage_reset_date: string | null;
   api_credit_balance?: number;
+  pending_plan_change?: {
+    id: string;
+    type: string;
+    target_plan_name: string;
+    status: string;
+    expires_at: string;
+  } | null;
 };
 
 type BillingRecurringInfo = {
@@ -312,6 +326,110 @@ export async function createZapriteCheckoutSession(
 
   // Fall back to regular navigation for web platforms
   window.location.href = checkout_url;
+}
+
+async function readBillingError(response: Response, fallback: string): Promise<never> {
+  const errorText = await response.text();
+  if (response.status === 401) {
+    throw new Error("Unauthorized");
+  }
+  const parsed = parseBillingApiError(errorText);
+  const error = new Error(parsed.error || fallback) as Error & { code?: string };
+  error.code = parsed.code;
+  throw error;
+}
+
+export async function createZapriteUpgradeQuote(
+  thirdPartyToken: string,
+  targetProductId: string
+): Promise<ZapriteUpgradeQuote> {
+  const response = await fetch(
+    `${import.meta.env.VITE_MAPLE_BILLING_API_URL}/v1/maple/subscription/zaprite/upgrade-quotes`,
+    {
+      method: "POST",
+      body: JSON.stringify({ target_product_id: targetProductId }),
+      headers: {
+        Authorization: `Bearer ${thirdPartyToken}`,
+        "Content-Type": "application/json"
+      }
+    }
+  );
+  if (!response.ok) {
+    await readBillingError(response, "Failed to create upgrade quote");
+  }
+  return response.json() as Promise<ZapriteUpgradeQuote>;
+}
+
+export async function createZapriteUpgrade(
+  thirdPartyToken: string,
+  quoteId: string,
+  idempotencyKey: string,
+  successUrl?: string
+): Promise<ZapriteUpgradeCreateResponse> {
+  const response = await fetch(
+    `${import.meta.env.VITE_MAPLE_BILLING_API_URL}/v1/maple/subscription/zaprite/upgrades`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        quote_id: quoteId,
+        ...(successUrl ? { success_url: successUrl } : {})
+      }),
+      headers: {
+        Authorization: `Bearer ${thirdPartyToken}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": idempotencyKey
+      }
+    }
+  );
+  if (!response.ok) {
+    await readBillingError(response, "Failed to create upgrade checkout");
+  }
+  const created = (await response.json()) as ZapriteUpgradeCreateResponse;
+  if (!isAllowedZapriteCheckoutUrl(created.checkout_url)) {
+    throw new Error("Checkout URL is not from the expected payment provider");
+  }
+  return created;
+}
+
+export async function fetchZapriteUpgradeStatus(
+  thirdPartyToken: string,
+  upgradeId: string
+): Promise<ZapriteUpgradeStatusResponse> {
+  const response = await fetch(
+    `${import.meta.env.VITE_MAPLE_BILLING_API_URL}/v1/maple/subscription/zaprite/upgrades/${upgradeId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${thirdPartyToken}`,
+        "Content-Type": "application/json"
+      }
+    }
+  );
+  if (!response.ok) {
+    await readBillingError(response, "Failed to fetch upgrade status");
+  }
+  return response.json() as Promise<ZapriteUpgradeStatusResponse>;
+}
+
+export async function openValidatedCheckoutUrl(checkoutUrl: string): Promise<void> {
+  if (!isAllowedZapriteCheckoutUrl(checkoutUrl)) {
+    throw new Error("Checkout URL is not from the expected payment provider");
+  }
+  if (isTauri()) {
+    const { invoke } = await import("@tauri-apps/api/core");
+    try {
+      await invoke("plugin:opener|open_url", { url: checkoutUrl });
+    } catch {
+      if (isMobile()) {
+        throw new Error(
+          "Failed to open payment page in external browser. This is required for mobile payments."
+        );
+      }
+      window.open(checkoutUrl, "_blank", "noopener");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    return;
+  }
+  window.open(checkoutUrl, "_blank", "noopener");
 }
 
 // Team Management API Functions

--- a/frontend/src/billing/billingApi.ts
+++ b/frontend/src/billing/billingApi.ts
@@ -429,7 +429,7 @@ export async function openValidatedCheckoutUrl(checkoutUrl: string): Promise<voi
     await new Promise((resolve) => setTimeout(resolve, 300));
     return;
   }
-  window.open(checkoutUrl, "_blank", "noopener");
+  window.location.href = checkoutUrl;
 }
 
 // Team Management API Functions

--- a/frontend/src/billing/billingService.ts
+++ b/frontend/src/billing/billingService.ts
@@ -34,8 +34,16 @@ import {
   redeemPassCode,
   PassCheckResponse,
   PassRedeemRequest,
-  PassRedeemResponse
+  PassRedeemResponse,
+  createZapriteUpgradeQuote,
+  createZapriteUpgrade,
+  fetchZapriteUpgradeStatus
 } from "./billingApi";
+import type {
+  ZapriteUpgradeCreateResponse,
+  ZapriteUpgradeQuote,
+  ZapriteUpgradeStatusResponse
+} from "./zapriteUpgrade";
 import type {
   TeamStatus,
   CreateTeamRequest,
@@ -213,6 +221,24 @@ class BillingService {
 
   async redeemPassCode(data: PassRedeemRequest): Promise<PassRedeemResponse> {
     return this.executeWithToken((token) => redeemPassCode(token, data));
+  }
+
+  async createZapriteUpgradeQuote(targetProductId: string): Promise<ZapriteUpgradeQuote> {
+    return this.executeWithToken((token) => createZapriteUpgradeQuote(token, targetProductId));
+  }
+
+  async createZapriteUpgrade(
+    quoteId: string,
+    idempotencyKey: string,
+    successUrl?: string
+  ): Promise<ZapriteUpgradeCreateResponse> {
+    return this.executeWithToken((token) =>
+      createZapriteUpgrade(token, quoteId, idempotencyKey, successUrl)
+    );
+  }
+
+  async getZapriteUpgradeStatus(upgradeId: string): Promise<ZapriteUpgradeStatusResponse> {
+    return this.executeWithToken((token) => fetchZapriteUpgradeStatus(token, upgradeId));
   }
 }
 

--- a/frontend/src/billing/zapriteUpgrade.test.ts
+++ b/frontend/src/billing/zapriteUpgrade.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+import {
+  isAllowedZapriteCheckoutUrl,
+  zapritePaidPlanButtonText,
+  zapriteUpgradeTarget
+} from "./zapriteUpgrade";
+import type { BillingStatus } from "./billingApi";
+
+const zapritePro: BillingStatus = {
+  is_subscribed: true,
+  stripe_customer_id: null,
+  product_id: "local-pro",
+  product_name: "Pro",
+  subscription_status: "active",
+  current_period_end: null,
+  can_chat: true,
+  chats_remaining: null,
+  payment_provider: "zaprite",
+  total_tokens: null,
+  used_tokens: null,
+  usage_reset_date: null
+};
+
+test("eligible Zaprite Pro renders upgrade CTA rather than support email", () => {
+  expect(zapritePaidPlanButtonText(zapritePro, { id: "local-max", name: "Max" }, false)).toBe(
+    "Upgrade to Max"
+  );
+  expect(zapriteUpgradeTarget(zapritePro, { id: "local-max", name: "Max" })).toBe(true);
+  expect(zapritePaidPlanButtonText(zapritePro, { id: "local-pro", name: "Pro" }, true)).toBe(
+    "Start Chatting"
+  );
+  expect(zapritePaidPlanButtonText(zapritePro, { id: "team", name: "Team" }, false)).toBe(
+    "Contact Us"
+  );
+});
+
+test("checkout URL allowlist accepts Zaprite and local mock hosts", () => {
+  expect(isAllowedZapriteCheckoutUrl("https://checkout.zaprite.com/abc")).toBe(true);
+  expect(isAllowedZapriteCheckoutUrl("http://checkout.zaprite.com/abc")).toBe(false);
+  expect(isAllowedZapriteCheckoutUrl("https://evil.example/abc")).toBe(false);
+  expect(isAllowedZapriteCheckoutUrl("http://127.0.0.1:36683/v1/dev/zaprite-mock/checkout/x")).toBe(
+    true
+  );
+});

--- a/frontend/src/billing/zapriteUpgrade.ts
+++ b/frontend/src/billing/zapriteUpgrade.ts
@@ -6,7 +6,8 @@ export const ZAPRITE_UPGRADE_TERMINAL_STATUSES = [
   "CANCELED",
   "FAILED",
   "REFUNDED",
-  "REVOKED"
+  "REVOKED",
+  "PAID_UNFULFILLABLE"
 ] as const;
 
 export type ZapriteUpgradeStatus =
@@ -22,6 +23,7 @@ export type ZapriteUpgradeStatus =
   | "CANCELED"
   | "FAILED"
   | "PAID_NEEDS_REVIEW"
+  | "PAID_UNFULFILLABLE"
   | "REFUNDED"
   | "REVOKED";
 

--- a/frontend/src/billing/zapriteUpgrade.ts
+++ b/frontend/src/billing/zapriteUpgrade.ts
@@ -4,7 +4,9 @@ export const ZAPRITE_UPGRADE_TERMINAL_STATUSES = [
   "COMPLETED",
   "EXPIRED",
   "CANCELED",
-  "FAILED"
+  "FAILED",
+  "REFUNDED",
+  "REVOKED"
 ] as const;
 
 export type ZapriteUpgradeStatus =
@@ -18,7 +20,10 @@ export type ZapriteUpgradeStatus =
   | "COMPLETED"
   | "EXPIRED"
   | "CANCELED"
-  | "FAILED";
+  | "FAILED"
+  | "PAID_NEEDS_REVIEW"
+  | "REFUNDED"
+  | "REVOKED";
 
 export type ZapriteUpgradePlanSummary = {
   product_id: string;

--- a/frontend/src/billing/zapriteUpgrade.ts
+++ b/frontend/src/billing/zapriteUpgrade.ts
@@ -1,0 +1,144 @@
+import type { BillingProduct, BillingStatus } from "./billingApi";
+
+export const ZAPRITE_UPGRADE_TERMINAL_STATUSES = [
+  "COMPLETED",
+  "EXPIRED",
+  "CANCELED",
+  "FAILED"
+] as const;
+
+export type ZapriteUpgradeStatus =
+  | "QUOTED"
+  | "CREATING_ORDER"
+  | "PENDING"
+  | "PROCESSING"
+  | "PAID"
+  | "UNDERPAID"
+  | "OVERPAID"
+  | "COMPLETED"
+  | "EXPIRED"
+  | "CANCELED"
+  | "FAILED";
+
+export type ZapriteUpgradePlanSummary = {
+  product_id: string;
+  plan_name: string;
+  monthly_amount_cents?: number;
+  annual_amount_cents: number;
+  discount_basis_points?: number;
+};
+
+export type ZapriteUpgradeQuote = {
+  quote_id: string;
+  source: ZapriteUpgradePlanSummary;
+  target: ZapriteUpgradePlanSummary;
+  subscription_start: string;
+  subscription_end: string;
+  quote_effective_at: string;
+  period_seconds: number;
+  remaining_seconds: number;
+  amount_due_cents: number;
+  currency: string;
+  expires_at: string;
+};
+
+export type ZapriteUpgradeCreateResponse = {
+  upgrade_id: string;
+  status: ZapriteUpgradeStatus;
+  checkout_url: string;
+  quote: ZapriteUpgradeQuote;
+};
+
+export type ZapriteUpgradeStatusResponse = {
+  upgrade_id: string;
+  status: ZapriteUpgradeStatus;
+  provider_status?: string;
+  quote: ZapriteUpgradeQuote;
+  checkout_url?: string;
+  completed_at?: string;
+};
+
+export type BillingApiError = {
+  error: string;
+  code?: string;
+};
+
+export function isZapriteUpgradeTerminal(status: string): boolean {
+  return (ZAPRITE_UPGRADE_TERMINAL_STATUSES as readonly string[]).includes(status);
+}
+
+export function formatUsdFromCents(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD"
+  }).format(cents / 100);
+}
+
+export function isAllowedZapriteCheckoutUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname;
+    if (
+      parsed.protocol === "https:" &&
+      (host === "checkout.zaprite.com" || host.endsWith(".zaprite.com"))
+    ) {
+      return true;
+    }
+    return (
+      parsed.protocol === "http:" &&
+      (host === "127.0.0.1" || host === "localhost" || host === "0.0.0.0")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function zapriteUpgradeTarget(
+  billingStatus: BillingStatus | null | undefined,
+  product: Pick<BillingProduct, "id" | "name">
+): boolean {
+  if (billingStatus?.payment_provider !== "zaprite") {
+    return false;
+  }
+  const source = billingStatus.product_name?.trim().toLowerCase() ?? "";
+  const target = product.name.trim().toLowerCase();
+  if (target.includes("team") || target.includes("starter") || target.includes("free")) {
+    return false;
+  }
+  if (source === "starter") {
+    return target === "pro" || target === "max";
+  }
+  if (source === "pro") {
+    return target === "max";
+  }
+  return false;
+}
+
+export function zapritePaidPlanButtonText(
+  billingStatus: BillingStatus | null | undefined,
+  product: Pick<BillingProduct, "id" | "name">,
+  isCurrentPlan: boolean
+): "Upgrade to Max" | "Upgrade to Pro" | "Contact Us" | "Start Chatting" | null {
+  if (billingStatus?.payment_provider !== "zaprite") {
+    return null;
+  }
+  if (isCurrentPlan) {
+    return "Start Chatting";
+  }
+  if (zapriteUpgradeTarget(billingStatus, product)) {
+    return product.name.trim().toLowerCase() === "max" ? "Upgrade to Max" : "Upgrade to Pro";
+  }
+  return "Contact Us";
+}
+
+export function parseBillingApiError(errorText: string): BillingApiError {
+  try {
+    const parsed = JSON.parse(errorText) as BillingApiError;
+    if (parsed && typeof parsed.error === "string") {
+      return parsed;
+    }
+  } catch {
+    // Fall through to the raw text.
+  }
+  return { error: errorText };
+}

--- a/frontend/src/components/ZapriteUpgradeDialog.tsx
+++ b/frontend/src/components/ZapriteUpgradeDialog.tsx
@@ -28,32 +28,40 @@ type ZapriteUpgradeDialogProps = {
   resumeUpgradeId?: string | null;
 };
 
-function statusCopy(status: string): string {
+function zapriteSuccessUrl(): string {
+  if (isMobile()) {
+    return "https://trymaple.ai/payment-success?source=zaprite";
+  }
+  if (isTauri()) {
+    return "https://trymaple.ai/pricing?success=true";
+  }
+  return `${window.location.origin}/pricing?success=true`;
+}
+
+function statusCopy(status: string, planName?: string): string {
   switch (status) {
     case "PENDING":
     case "PROCESSING":
     case "PAID":
     case "OVERPAID":
-      return "Waiting for Bitcoin payment to confirm. Your current plan stays active until payment completes.";
+      return "Waiting for payment.";
     case "UNDERPAID":
-      return "The payment is underpaid. Send the remaining amount in the checkout window, or contact support.";
+      return "Payment is short.";
     case "COMPLETED":
-      return "Upgrade complete. Your Max entitlement is now active for the rest of this billing period.";
+      return planName ? `You're on ${planName}.` : "Upgrade complete.";
     case "EXPIRED":
-      return "This quote or checkout expired. Your current plan is unchanged.";
+      return "This quote expired.";
     case "CANCELED":
-      return "This upgrade was canceled. Your current plan is unchanged.";
     case "FAILED":
-      return "This upgrade could not be completed. Your current plan is unchanged.";
+      return "Upgrade could not be completed.";
     case "PAID_NEEDS_REVIEW":
-      return "Payment was received and needs a short review before the plan change is applied. Your current plan is unchanged.";
     case "PAID_UNFULFILLABLE":
-      return "Payment was received after this upgrade was replaced. Your current plan is unchanged; contact support for the extra payment.";
+      return "Payment received. Contact support if your plan doesn't update.";
     case "REFUNDED":
     case "REVOKED":
-      return "This upgrade is no longer active. Your current plan is unchanged.";
+      return "This upgrade is no longer active.";
     default:
-      return "Preparing Bitcoin checkout.";
+      return "Preparing checkout.";
   }
 }
 
@@ -140,14 +148,10 @@ export function ZapriteUpgradeDialog({
     setSubmitting(true);
     setError(null);
     try {
-      const successUrl =
-        isTauri() || isMobile()
-          ? "https://trymaple.ai/pricing"
-          : `${window.location.origin}/pricing`;
       const created = await getBillingService().createZapriteUpgrade(
         displayedQuote.quote_id,
         idempotencyKey,
-        successUrl
+        zapriteSuccessUrl()
       );
       if (mountedUserId.current !== userId) {
         return;
@@ -166,14 +170,15 @@ export function ZapriteUpgradeDialog({
   const checkoutUrl = upgradeStatus?.checkout_url;
   const canReopenCheckout =
     !!checkoutUrl && !isIOS() && !!currentStatus && !isZapriteUpgradeTerminal(currentStatus);
+  const targetName = displayedQuote?.target.plan_name ?? "Max";
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Upgrade with Bitcoin</DialogTitle>
-          <DialogDescription>
-            The billing server computed this exact amount. Maple does not recalculate the price.
+          <DialogTitle>Upgrade to {targetName}</DialogTitle>
+          <DialogDescription className="sr-only">
+            Confirm your Bitcoin upgrade to {targetName}.
           </DialogDescription>
         </DialogHeader>
 
@@ -182,44 +187,40 @@ export function ZapriteUpgradeDialog({
         {!displayedQuote && !error && (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
-            Loading quote...
+            Loading...
           </div>
         )}
 
-        {displayedQuote && (
-          <div className="space-y-3 text-sm">
-            <p>
-              {displayedQuote.source.plan_name} → {displayedQuote.target.plan_name}
+        {displayedQuote && !currentStatus && (
+          <div className="space-y-1">
+            <p className="text-2xl font-semibold">
+              {formatUsdFromCents(displayedQuote.amount_due_cents)}
             </p>
-            <p>
-              Unused {displayedQuote.source.plan_name} value is credited against the remaining{" "}
-              {displayedQuote.target.plan_name} term. Your expiration date stays{" "}
-              {new Date(displayedQuote.subscription_end).toLocaleDateString()}.
+            <p className="text-sm text-muted-foreground">
+              Renews {new Date(displayedQuote.subscription_end).toLocaleDateString()}
             </p>
-            <p>
-              Amount due: <strong>{formatUsdFromCents(displayedQuote.amount_due_cents)}</strong>
-              {displayedQuote.target.discount_basis_points
-                ? ` including a ${displayedQuote.target.discount_basis_points / 100}% annual Bitcoin discount.`
-                : "."}
-            </p>
-            <p>Quote expires {new Date(displayedQuote.expires_at).toLocaleString()}.</p>
-            {currentStatus && <p>{statusCopy(currentStatus)}</p>}
           </div>
+        )}
+
+        {currentStatus && (
+          <p className="text-sm text-muted-foreground">
+            {statusCopy(currentStatus, displayedQuote?.target.plan_name)}
+          </p>
         )}
 
         {isIOS() && (
           <p className="text-sm text-muted-foreground">
-            Paid Bitcoin upgrades are not available in the iOS app.
+            Bitcoin upgrades aren't available in the iOS app.
           </p>
         )}
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Close
+            {currentStatus === "COMPLETED" ? "Done" : "Cancel"}
           </Button>
           {canConfirm && (
             <Button variant="primary" onClick={handleConfirm} disabled={submitting}>
-              {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Confirm and pay"}
+              {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Pay with Bitcoin"}
             </Button>
           )}
           {canReopenCheckout && checkoutUrl && (
@@ -231,7 +232,7 @@ export function ZapriteUpgradeDialog({
                 });
               }}
             >
-              Open checkout
+              Continue to payment
             </Button>
           )}
         </DialogFooter>

--- a/frontend/src/components/ZapriteUpgradeDialog.tsx
+++ b/frontend/src/components/ZapriteUpgradeDialog.tsx
@@ -18,7 +18,7 @@ import {
   type ZapriteUpgradeQuote,
   type ZapriteUpgradeStatusResponse
 } from "@/billing/zapriteUpgrade";
-import { isIOS } from "@/utils/platform";
+import { isIOS, isMobile, isTauri } from "@/utils/platform";
 
 type ZapriteUpgradeDialogProps = {
   open: boolean;
@@ -133,10 +133,14 @@ export function ZapriteUpgradeDialog({
     setSubmitting(true);
     setError(null);
     try {
+      const successUrl =
+        isTauri() || isMobile()
+          ? "https://trymaple.ai/pricing"
+          : `${window.location.origin}/pricing`;
       const created = await getBillingService().createZapriteUpgrade(
         displayedQuote.quote_id,
         idempotencyKey,
-        `${window.location.origin}/pricing`
+        successUrl
       );
       if (mountedUserId.current !== userId) {
         return;
@@ -152,6 +156,9 @@ export function ZapriteUpgradeDialog({
 
   const currentStatus = upgradeStatus?.status;
   const canConfirm = !!displayedQuote && !upgradeId && !isIOS() && !submitting;
+  const checkoutUrl = upgradeStatus?.checkout_url;
+  const canReopenCheckout =
+    !!checkoutUrl && !isIOS() && !!currentStatus && !isZapriteUpgradeTerminal(currentStatus);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -206,6 +213,18 @@ export function ZapriteUpgradeDialog({
           {canConfirm && (
             <Button variant="primary" onClick={handleConfirm} disabled={submitting}>
               {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Confirm and pay"}
+            </Button>
+          )}
+          {canReopenCheckout && checkoutUrl && (
+            <Button
+              variant="primary"
+              onClick={() => {
+                void openValidatedCheckoutUrl(checkoutUrl).catch((err: unknown) => {
+                  setError(err instanceof Error ? err.message : "Failed to open checkout");
+                });
+              }}
+            >
+              Open checkout
             </Button>
           )}
         </DialogFooter>

--- a/frontend/src/components/ZapriteUpgradeDialog.tsx
+++ b/frontend/src/components/ZapriteUpgradeDialog.tsx
@@ -47,6 +47,8 @@ function statusCopy(status: string): string {
       return "This upgrade could not be completed. Your current plan is unchanged.";
     case "PAID_NEEDS_REVIEW":
       return "Payment was received and needs a short review before the plan change is applied. Your current plan is unchanged.";
+    case "PAID_UNFULFILLABLE":
+      return "Payment was received after this upgrade was replaced. Your current plan is unchanged; contact support for the extra payment.";
     case "REFUNDED":
     case "REVOKED":
       return "This upgrade is no longer active. Your current plan is unchanged.";

--- a/frontend/src/components/ZapriteUpgradeDialog.tsx
+++ b/frontend/src/components/ZapriteUpgradeDialog.tsx
@@ -1,0 +1,215 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { getBillingService } from "@/billing/billingService";
+import { openValidatedCheckoutUrl } from "@/billing/billingApi";
+import {
+  formatUsdFromCents,
+  isZapriteUpgradeTerminal,
+  type ZapriteUpgradeQuote,
+  type ZapriteUpgradeStatusResponse
+} from "@/billing/zapriteUpgrade";
+import { isIOS } from "@/utils/platform";
+
+type ZapriteUpgradeDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  userId: string | null;
+  targetProductId: string | null;
+  resumeUpgradeId?: string | null;
+};
+
+function statusCopy(status: string): string {
+  switch (status) {
+    case "PENDING":
+    case "PROCESSING":
+    case "PAID":
+    case "OVERPAID":
+      return "Waiting for Bitcoin payment to confirm. Your current plan stays active until payment completes.";
+    case "UNDERPAID":
+      return "The payment is underpaid. Send the remaining amount in the checkout window, or contact support.";
+    case "COMPLETED":
+      return "Upgrade complete. Your Max entitlement is now active for the rest of this billing period.";
+    case "EXPIRED":
+      return "This quote or checkout expired. Your current plan is unchanged.";
+    case "CANCELED":
+      return "This upgrade was canceled. Your current plan is unchanged.";
+    case "FAILED":
+      return "This upgrade could not be completed. Your current plan is unchanged.";
+    default:
+      return "Preparing Bitcoin checkout.";
+  }
+}
+
+export function ZapriteUpgradeDialog({
+  open,
+  onOpenChange,
+  userId,
+  targetProductId,
+  resumeUpgradeId
+}: ZapriteUpgradeDialogProps) {
+  const queryClient = useQueryClient();
+  const [quote, setQuote] = useState<ZapriteUpgradeQuote | null>(null);
+  const [upgradeId, setUpgradeId] = useState<string | null>(resumeUpgradeId ?? null);
+  const [idempotencyKey] = useState(() => crypto.randomUUID());
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const mountedUserId = useRef(userId);
+
+  useEffect(() => {
+    mountedUserId.current = userId;
+  }, [userId]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setError(null);
+    if (resumeUpgradeId) {
+      setUpgradeId(resumeUpgradeId);
+      return;
+    }
+    if (!targetProductId) {
+      return;
+    }
+    let cancelled = false;
+    setQuote(null);
+    getBillingService()
+      .createZapriteUpgradeQuote(targetProductId)
+      .then((nextQuote) => {
+        if (!cancelled && mountedUserId.current === userId) {
+          setQuote(nextQuote);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load upgrade quote");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, resumeUpgradeId, targetProductId, userId]);
+
+  const { data: upgradeStatus } = useQuery<ZapriteUpgradeStatusResponse>({
+    queryKey: ["zapriteUpgrade", userId, upgradeId],
+    queryFn: async () => {
+      if (!upgradeId) {
+        throw new Error("Missing upgrade id");
+      }
+      return getBillingService().getZapriteUpgradeStatus(upgradeId);
+    },
+    enabled: open && !!userId && !!upgradeId,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (!status || isZapriteUpgradeTerminal(status)) {
+        return false;
+      }
+      return 2000;
+    }
+  });
+
+  useEffect(() => {
+    if (upgradeStatus?.status === "COMPLETED" && mountedUserId.current === userId) {
+      void queryClient.invalidateQueries({ queryKey: ["billingStatus"] });
+    }
+  }, [upgradeStatus?.status, queryClient, userId]);
+
+  const displayedQuote = upgradeStatus?.quote ?? quote;
+
+  const handleConfirm = useCallback(async () => {
+    if (!displayedQuote || isIOS()) {
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const created = await getBillingService().createZapriteUpgrade(
+        displayedQuote.quote_id,
+        idempotencyKey,
+        `${window.location.origin}/pricing`
+      );
+      if (mountedUserId.current !== userId) {
+        return;
+      }
+      setUpgradeId(created.upgrade_id);
+      await openValidatedCheckoutUrl(created.checkout_url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start Bitcoin checkout");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [displayedQuote, idempotencyKey, userId]);
+
+  const currentStatus = upgradeStatus?.status;
+  const canConfirm = !!displayedQuote && !upgradeId && !isIOS() && !submitting;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Upgrade with Bitcoin</DialogTitle>
+          <DialogDescription>
+            The billing server computed this exact amount. Maple does not recalculate the price.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && <p className="text-sm text-maple-error">{error}</p>}
+
+        {!displayedQuote && !error && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading quote...
+          </div>
+        )}
+
+        {displayedQuote && (
+          <div className="space-y-3 text-sm">
+            <p>
+              {displayedQuote.source.plan_name} → {displayedQuote.target.plan_name}
+            </p>
+            <p>
+              Unused {displayedQuote.source.plan_name} value is credited against the remaining{" "}
+              {displayedQuote.target.plan_name} term. Your expiration date stays{" "}
+              {new Date(displayedQuote.subscription_end).toLocaleDateString()}.
+            </p>
+            <p>
+              Amount due: <strong>{formatUsdFromCents(displayedQuote.amount_due_cents)}</strong>
+              {displayedQuote.target.discount_basis_points
+                ? ` including a ${displayedQuote.target.discount_basis_points / 100}% annual Bitcoin discount.`
+                : "."}
+            </p>
+            <p>Quote expires {new Date(displayedQuote.expires_at).toLocaleString()}.</p>
+            {currentStatus && <p>{statusCopy(currentStatus)}</p>}
+          </div>
+        )}
+
+        {isIOS() && (
+          <p className="text-sm text-muted-foreground">
+            Paid Bitcoin upgrades are not available in the iOS app.
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+          {canConfirm && (
+            <Button variant="primary" onClick={handleConfirm} disabled={submitting}>
+              {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Confirm and pay"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ZapriteUpgradeDialog.tsx
+++ b/frontend/src/components/ZapriteUpgradeDialog.tsx
@@ -45,6 +45,11 @@ function statusCopy(status: string): string {
       return "This upgrade was canceled. Your current plan is unchanged.";
     case "FAILED":
       return "This upgrade could not be completed. Your current plan is unchanged.";
+    case "PAID_NEEDS_REVIEW":
+      return "Payment was received and needs a short review before the plan change is applied. Your current plan is unchanged.";
+    case "REFUNDED":
+    case "REVOKED":
+      return "This upgrade is no longer active. Your current plan is unchanged.";
     default:
       return "Preparing Bitcoin checkout.";
   }

--- a/frontend/src/routes/pricing.tsx
+++ b/frontend/src/routes/pricing.tsx
@@ -23,6 +23,8 @@ import { Switch } from "@/components/ui/switch";
 import { PRICING_PLANS } from "@/config/pricingConfig";
 import { VerificationModal } from "@/components/VerificationModal";
 import { TeamSeatDialog } from "@/components/TeamSeatDialog";
+import { ZapriteUpgradeDialog } from "@/components/ZapriteUpgradeDialog";
+import { zapritePaidPlanButtonText, zapriteUpgradeTarget } from "@/billing/zapriteUpgrade";
 import { isIOS, isAndroid, isMobile, isTauri } from "@/utils/platform";
 import { cn } from "@/utils/utils";
 import packageJson from "../../package.json";
@@ -243,6 +245,8 @@ function PricingPage() {
   const [useBitcoin, setUseBitcoin] = useState(false);
   const [showTeamSeatDialog, setShowTeamSeatDialog] = useState(false);
   const [pendingTeamProductId, setPendingTeamProductId] = useState<string | null>(null);
+  const [zapriteUpgradeProductId, setZapriteUpgradeProductId] = useState<string | null>(null);
+  const [zapriteUpgradeOpen, setZapriteUpgradeOpen] = useState(false);
   const navigate = useNavigate();
   const os = useOpenSecret();
   const { setBillingStatus } = useBillingState();
@@ -364,9 +368,9 @@ function PricingPage() {
     const currentPlanName = freshBillingStatus?.product_name?.toLowerCase();
     const isCurrentPlan = currentPlanName === targetPlanName;
 
-    // If user is on Zaprite plan, show Contact Us
-    if (freshBillingStatus?.payment_provider === "zaprite") {
-      return "Contact Us";
+    const zapriteButton = zapritePaidPlanButtonText(freshBillingStatus, product, isCurrentPlan);
+    if (zapriteButton) {
+      return zapriteButton;
     }
 
     // If user is on subscription pass, only show button for current plan
@@ -544,9 +548,12 @@ function PricingPage() {
         return;
       }
 
-      // If user is on Zaprite plan, redirect to email
       if (freshBillingStatus?.payment_provider === "zaprite") {
-        // Use Tauri opener plugin for all Tauri platforms, fallback to window.location for web
+        if (zapriteUpgradeTarget(freshBillingStatus, product) && !isIOSPlatform) {
+          setZapriteUpgradeProductId(product.id);
+          setZapriteUpgradeOpen(true);
+          return;
+        }
         if (isTauri()) {
           import("@tauri-apps/api/core")
             .then((coreModule) => {
@@ -554,12 +561,7 @@ function PricingPage() {
                 url: "mailto:support@trymaple.ai"
               });
             })
-            .then(() => {
-              console.log("[Contact] Successfully opened mailto link with Tauri opener");
-            })
-            .catch((err) => {
-              console.error("[Contact] Failed to open mailto link with Tauri opener:", err);
-              // Fallback for web or if Tauri fails
+            .catch(() => {
               window.location.href = "mailto:support@trymaple.ai";
             });
         } else {
@@ -786,13 +788,34 @@ function PricingPage() {
         <PricingHero />
 
         {/* Payment Callback Status Messages */}
-        {success && (
+        {success && freshBillingStatus?.payment_provider !== "zaprite" && (
           <div className="w-full max-w-7xl mx-auto mt-4 px-4 sm:px-6 lg:px-8">
             <div className="flex items-center gap-3 rounded-lg border border-maple-success/30 bg-maple-success/10 p-4 text-maple-success">
               <div className="rounded-full bg-maple-success/10 p-1">
                 <Check className="w-5 h-5" />
               </div>
               <p>Payment successful! Your subscription has been updated.</p>
+            </div>
+          </div>
+        )}
+
+        {freshBillingStatus?.pending_plan_change && (
+          <div className="w-full max-w-7xl mx-auto mt-4 px-4 sm:px-6 lg:px-8">
+            <div className="flex items-center justify-between gap-3 rounded-lg border border-maple-warning/35 bg-maple-warning/10 p-4 text-maple-warning">
+              <p>
+                Bitcoin upgrade to {freshBillingStatus.pending_plan_change.target_plan_name} is{" "}
+                {freshBillingStatus.pending_plan_change.status.toLowerCase()}. Your current plan is
+                unchanged until payment completes.
+              </p>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setZapriteUpgradeProductId(null);
+                  setZapriteUpgradeOpen(true);
+                }}
+              >
+                View status
+              </Button>
             </div>
           </div>
         )}
@@ -1144,6 +1167,15 @@ function PricingPage() {
         open={showTeamSeatDialog}
         onOpenChange={setShowTeamSeatDialog}
         onConfirm={handleTeamSeatConfirm}
+      />
+      <ZapriteUpgradeDialog
+        open={zapriteUpgradeOpen}
+        onOpenChange={setZapriteUpgradeOpen}
+        userId={os.auth.user?.user.id ?? null}
+        targetProductId={zapriteUpgradeProductId}
+        resumeUpgradeId={
+          zapriteUpgradeProductId ? null : (freshBillingStatus?.pending_plan_change?.id ?? null)
+        }
       />
       <VerificationModal />
     </>

--- a/frontend/src/routes/pricing.tsx
+++ b/frontend/src/routes/pricing.tsx
@@ -549,6 +549,11 @@ function PricingPage() {
       }
 
       if (freshBillingStatus?.payment_provider === "zaprite") {
+        const currentPlanName = freshBillingStatus.product_name?.toLowerCase();
+        if (currentPlanName === targetPlanName) {
+          navigate({ to: "/" });
+          return;
+        }
         if (zapriteUpgradeTarget(freshBillingStatus, product) && !isIOSPlatform) {
           setZapriteUpgradeProductId(product.id);
           setZapriteUpgradeOpen(true);

--- a/frontend/src/routes/pricing.tsx
+++ b/frontend/src/routes/pricing.tsx
@@ -808,9 +808,8 @@ function PricingPage() {
           <div className="w-full max-w-7xl mx-auto mt-4 px-4 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between gap-3 rounded-lg border border-maple-warning/35 bg-maple-warning/10 p-4 text-maple-warning">
               <p>
-                Bitcoin upgrade to {freshBillingStatus.pending_plan_change.target_plan_name} is{" "}
-                {freshBillingStatus.pending_plan_change.status.toLowerCase()}. Your current plan is
-                unchanged until payment completes.
+                Upgrade to {freshBillingStatus.pending_plan_change.target_plan_name} is waiting for
+                payment.
               </p>
               <Button
                 variant="outline"
@@ -819,7 +818,7 @@ function PricingPage() {
                   setZapriteUpgradeOpen(true);
                 }}
               >
-                View status
+                Continue
               </Button>
             </div>
           </div>


### PR DESCRIPTION
Companion to https://github.com/OpenSecretCloud/maple-billing-server/pull/92 and maple-billing-server issue 91.

## Summary

Eligible Zaprite Pro (and legacy Starter) subscribers see an **Upgrade to Max** CTA instead of Contact Us. Maple displays the billing-server quote without recalculating proration, opens one allowlisted checkout URL, and polls authenticated upgrade status until completion. Redirect success query parameters are no longer treated as payment confirmation for Zaprite.

iOS paid-purchase restrictions are unchanged.

## Test plan

- [x] Unit tests for CTA eligibility and checkout URL allowlist.
- [x] Frontend lint/typecheck and pre-commit test suite.
- [x] Local Maple web: login as fixture Zaprite Pro, quote dialog, confirm, mock complete, UI shows Max entitlement.
- [ ] Desktop/Android opener path with a real Zaprite checkout URL.
- [ ] Confirm iOS remains unavailable.
