### PR TITLE
Own Pages publishing with guarded preview and release artifacts

### DIFF
--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -15,9 +15,14 @@ commit, external effect, and authority provided by the user.
   frontend, and Rust workflows. The iOS master workflow uploads its verified
   IPA to TestFlight automatically.
 - Creating a GitHub Release starts the cross-platform release workflow. A
-  successful release workflow starts separate updater-metadata, Pages
-  production-branch, and best-effort Zapstore workflows. These sibling
-  workflows never gate or change the outcome of the core Maple release.
+  successful release workflow starts separate updater-metadata, Pages, and
+  best-effort Zapstore workflows. These siblings never gate or change the core
+  Maple release. Pages has staged modes: `Promote Pages production` advances the
+  branch for native Cloudflare builds by default; when repository variable
+  `MAPLE_PAGES_PRODUCTION_ENABLED=true`, `Publish Pages` uploads the verified
+  existing release web artifact instead. Read
+  [the Pages deployment guide](../../../docs/pages-deployments.md) before changing
+  its mode, protected environments, or Cloudflare build controls.
 - The same Maple GitHub Release receives four native `maple-proxy` archives and
   their checksum manifest. Never create a separate proxy Release or proxy tag;
   `/releases/latest` must continue to identify the Maple application release.
@@ -165,10 +170,20 @@ gh run list --repo OpenSecretCloud/Maple --workflow 'Publish updater metadata' \
   --commit "$head_sha" --limit 10 \
   --json databaseId,status,conclusion,headSha,createdAt,url
 
-gh run list --repo OpenSecretCloud/Maple --workflow 'Promote Pages production' \
-  --commit "$head_sha" --limit 10 \
+pages_workflow='Promote Pages production'
+pages_enabled="$(gh variable list --repo OpenSecretCloud/Maple --json name,value \
+  --jq '.[] | select(.name == "MAPLE_PAGES_PRODUCTION_ENABLED") | .value')" || exit 1
+if [ "$pages_enabled" = true ]; then
+  pages_workflow='Publish Pages'
+fi
+gh run list --repo OpenSecretCloud/Maple --workflow "$pages_workflow" \
+  --limit 10 \
   --json databaseId,status,conclusion,headSha,createdAt,url
 ```
+
+The publisher executes trusted master, which can be newer than the release.
+Inspect its production job's validated source SHA instead of filtering runs by
+the workflow checkout SHA; preview publication uses the same workflow name.
 
 Also inspect the independent proxy-container publisher. It should either prove
 the expected immutable proxy version, public AMD64/ARM64 manifest, per-platform
@@ -183,20 +198,24 @@ gh run list --repo OpenSecretCloud/Maple --workflow 'Publish proxy container' \
 ```
 
 The updater workflow must publish the verified `latest.json` before reporting
-the desktop updater control plane current. The Pages workflow advances the
-machine-owned `pages-production` ref to the exact stable release SHA; its
-success proves the ref mutation, not Cloudflare's external build or live-site
-result. Verify the corresponding Cloudflare Pages check/deployment separately
-before reporting Maple web production current. A failure in either sibling is
-reported and repaired in that workflow without changing the completed release
-artifacts.
+the desktop updater control plane current. In legacy Pages mode, a successful
+promoter proves only the `pages-production` ref mutation; verify Cloudflare's
+separate build result. In owned-publisher mode, require the `production` job in
+`Publish Pages` to succeed: it validates the release asset, uploads without a
+rebuild, checks CF stage/commit/active canonical deployment, and then advances
+the ref without force. Neither result proves browser login/chat or configuration.
+Report and repair sibling failures without altering completed release artifacts.
 
-Confirm the production ref and inspect Cloudflare's exact-commit check:
+Confirm the production ref in either mode:
 
 ```bash
 pages_sha="$(gh api repos/OpenSecretCloud/Maple/git/ref/heads/pages-production --jq .object.sha)"
 [[ "$pages_sha" == "$head_sha" ]]
+```
 
+In legacy mode only, inspect Cloudflare's exact-commit check:
+
+```bash
 gh api "repos/OpenSecretCloud/Maple/commits/$head_sha/check-runs" --jq '
   [.check_runs[]
    | select(.name == "Cloudflare Pages")
@@ -204,13 +223,19 @@ gh api "repos/OpenSecretCloud/Maple/commits/$head_sha/check-runs" --jq '
    | {status, conclusion, started_at, completed_at, details_url}]'
 ```
 
-Require a completed successful Cloudflare Pages check corresponding to the
-production-branch promotion, not merely an older preview check on the same
-commit. Inspect its `details_url` when the commit has multiple Pages checks.
-A raw `curl` from an automated VM may be denied by Cloudflare edge policy; a
-Cloudflare-owned successful production check is deployment proof, while an
-allowed-browser smoke is separate live-application evidence. Record either
-boundary instead of turning an edge-policy 403 into a release failure.
+Require the successful Cloudflare check for the production-branch promotion,
+not an older preview check on the same commit. In owned-publisher mode, inspect
+the `Publish Pages` production job summary and GitHub deployment instead; the
+old Cloudflare App check is no longer produced by this path. The summary names
+the deployment ID and SHA. A failed post-upload freshness/ref/status check can
+leave a new CF deployment already active: inspect actual canonical state before
+retrying, and follow the deployment guide's hold/rollback procedure.
+
+A raw `curl` from an automated VM may be denied by edge policy. An allowed-browser
+smoke is separate application evidence; do not turn an edge-policy 403 into a
+release failure. Once owned publishing is enabled, manually dispatch
+`Publish Pages` from master to retry the current verified stable release; never
+recreate a Release or rerun the core release merely to repair Pages.
 
 On failure, read the failed logs before acting:
 

--- a/.github/workflows/pages-preview-build.yml
+++ b/.github/workflows/pages-preview-build.yml
@@ -1,0 +1,111 @@
+name: Pages preview build
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - ".github/workflows/web-build.yml"
+      - ".github/workflows/pages-*.yml"
+      - "frontend/**"
+      - "!frontend/src-tauri/**"
+      - "sdk/src/**"
+      - "!sdk/src/lib/test/**"
+      - "sdk/bun.lock"
+      - "sdk/bunfig.toml"
+      - "sdk/package.json"
+      - "sdk/tsconfig.build.json"
+      - "sdk/tsconfig.json"
+      - "sdk/vite.config.ts"
+      - "scripts/prepare-frontend-deps.sh"
+      - "scripts/prepare-typescript-sdk.sh"
+      - "scripts/ci/_common.sh"
+      - "scripts/ci/web.sh"
+      - "scripts/ci/pages_*.py"
+      - "scripts/ci/test_pages_*.py"
+      - "flake.nix"
+      - "flake.lock"
+  pull_request:
+    branches: [master]
+    paths:
+      - ".github/workflows/web-build.yml"
+      - ".github/workflows/pages-*.yml"
+      - "frontend/**"
+      - "!frontend/src-tauri/**"
+      - "sdk/src/**"
+      - "!sdk/src/lib/test/**"
+      - "sdk/bun.lock"
+      - "sdk/bunfig.toml"
+      - "sdk/package.json"
+      - "sdk/tsconfig.build.json"
+      - "sdk/tsconfig.json"
+      - "sdk/vite.config.ts"
+      - "scripts/prepare-frontend-deps.sh"
+      - "scripts/prepare-typescript-sdk.sh"
+      - "scripts/ci/_common.sh"
+      - "scripts/ci/web.sh"
+      - "scripts/ci/pages_*.py"
+      - "scripts/ci/test_pages_*.py"
+      - "flake.nix"
+      - "flake.lock"
+
+jobs:
+  build-preview:
+    # Untrusted PR code runs here without deployment credentials or write permissions.
+    # Fork PRs retain their existing CI checks, but do not get a hosted Pages preview.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 30
+    env:
+      SOURCE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - name: Checkout preview source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          persist-credentials: false
+
+      - name: Checkout workflow tooling
+        # Older PR heads may not contain the deployment tooling yet. This is the
+        # unprivileged workflow/merge SHA; the publisher still distrusts its output.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          path: .pages-tools
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          github-token: ""
+
+      - name: Build with development services
+        run: nix develop --no-update-lock-file .#ci -c ./scripts/ci/web.sh
+        env:
+          MAPLE_WEB_ENVIRONMENT: pr
+
+      - name: Describe the preview artifact
+        run: |
+          nix develop --no-update-lock-file "$GITHUB_WORKSPACE/.pages-tools#pages" \
+            -c python3 -I "$GITHUB_WORKSPACE/.pages-tools/scripts/ci/pages_artifact.py" manifest \
+            --archive frontend/src-tauri/target/reproducibility/maple-web-dist.tar.gz \
+            --profile pr \
+            --sha "$SOURCE_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --output frontend/src-tauri/target/reproducibility/pages-artifact.json
+
+      - name: Upload the preview artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: maple-pages-preview-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            frontend/src-tauri/target/reproducibility/maple-web-dist.tar.gz
+            frontend/src-tauri/target/reproducibility/pages-artifact.json
+          if-no-files-found: error
+          retention-days: 5

--- a/.github/workflows/pages-production.yml
+++ b/.github/workflows/pages-production.yml
@@ -19,12 +19,13 @@ jobs:
   promote:
     name: Advance pages-production
     if: >-
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') ||
-      (github.event_name == 'workflow_run' &&
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'release' &&
-        github.event.workflow_run.path == '.github/workflows/release.yml' &&
-        github.event.workflow_run.head_repository.full_name == github.repository)
+      vars.MAPLE_PAGES_PRODUCTION_ENABLED != 'true' &&
+      ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') ||
+        (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'release' &&
+          github.event.workflow_run.path == '.github/workflows/release.yml' &&
+          github.event.workflow_run.head_repository.full_name == github.repository))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/pages-publish.yml
+++ b/.github/workflows/pages-publish.yml
@@ -1,0 +1,122 @@
+name: Publish Pages
+
+on:
+  workflow_run:
+    workflows: ["Pages preview build", "Release"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    name: Publish development preview
+    if: >-
+      vars.MAPLE_PAGES_PREVIEW_ENABLED == 'true' &&
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.path == '.github/workflows/pages-preview-build.yml' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      (github.event.workflow_run.event == 'pull_request' ||
+        (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'master'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: pages-preview-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: false
+    environment:
+      name: pages-preview
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+      deployments: write
+    steps:
+      # workflow_run uses the default branch SHA. Never checkout or execute the
+      # triggering PR's scripts, dependencies, workflow, or deployment config here.
+      - name: Checkout trusted publisher
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          github-token: ""
+
+      - name: Install trusted deployment dependencies
+        working-directory: updates
+        run: nix develop --no-update-lock-file ..#pages -c bun install --frozen-lockfile --ignore-scripts
+
+      - name: Verify and prepare the preview artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          nix develop --no-update-lock-file .#pages -c python3 -I scripts/ci/pages_deploy.py
+          prepare --target preview --state "$RUNNER_TEMP/maple-pages"
+
+      - name: Deploy the verified preview
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: >-
+          nix develop --no-update-lock-file .#pages -c python3 -I scripts/ci/pages_deploy.py
+          deploy --state "$RUNNER_TEMP/maple-pages"
+
+  production:
+    name: Publish current stable release
+    if: >-
+      vars.MAPLE_PAGES_PRODUCTION_ENABLED == 'true' &&
+      ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') ||
+        (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'release' &&
+          github.event.workflow_run.path == '.github/workflows/release.yml' &&
+          github.event.workflow_run.head_repository.full_name == github.repository))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      # Shared with the legacy promoter so rollout cannot run two production writers.
+      group: pages-production
+      cancel-in-progress: false
+    environment:
+      name: pages-production
+      url: https://trymaple.ai
+    permissions:
+      contents: write
+      actions: read
+      deployments: write
+    steps:
+      - name: Checkout trusted publisher
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          github-token: ""
+
+      - name: Install trusted deployment dependencies
+        working-directory: updates
+        run: nix develop --no-update-lock-file ..#pages -c bun install --frozen-lockfile --ignore-scripts
+
+      - name: Verify and prepare the stable release artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          nix develop --no-update-lock-file .#pages -c python3 -I scripts/ci/pages_deploy.py
+          prepare --target production --state "$RUNNER_TEMP/maple-pages"
+
+      - name: Deploy the verified stable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: >-
+          nix develop --no-update-lock-file .#pages -c python3 -I scripts/ci/pages_deploy.py
+          deploy --state "$RUNNER_TEMP/maple-pages"

--- a/.github/workflows/pages-tests.yml
+++ b/.github/workflows/pages-tests.yml
@@ -1,0 +1,46 @@
+name: Pages deployment tests
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/pages-*.yml"
+      - "scripts/ci/pages_*.py"
+      - "scripts/ci/test_pages_*.py"
+      - "scripts/ci/_common.sh"
+      - "scripts/ci/web.sh"
+      - "updates/package.json"
+      - "updates/bun.lock"
+      - "flake.nix"
+      - "flake.lock"
+  push:
+    branches: [master]
+    paths:
+      - ".github/workflows/pages-*.yml"
+      - "scripts/ci/pages_*.py"
+      - "scripts/ci/test_pages_*.py"
+      - "scripts/ci/_common.sh"
+      - "scripts/ci/web.sh"
+      - "updates/package.json"
+      - "updates/bun.lock"
+      - "flake.nix"
+      - "flake.lock"
+
+jobs:
+  pages:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          github-token: ""
+
+      - name: Test Pages artifact and deployment boundaries
+        run: nix build --no-update-lock-file --no-link --print-build-logs .#checks.x86_64-linux.pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,12 @@ new in-repository dependency makes one component an app build input, update the
 classifier and its table-driven tests in the same change that wires the
 dependency.
 
+For Pages publishing, read [the deployment guide](docs/pages-deployments.md).
+Keep preview builds unprivileged, preserve development/production build profiles,
+and run credential-bearing publication only from trusted master. The new Pages
+publisher is opt-in; deployment flags, protected environments, and native CF
+build controls are separate operator prerequisites, not consequences of merging.
+
 PR artifact scripts deliberately ignore local `.env*` files and compile fixed
 PR endpoints. They prove PR packaging, not a configured local-backend runtime.
 For the latter, preserve the checkout's `frontend/.env.local`, use

--- a/docs/pages-deployments.md
+++ b/docs/pages-deployments.md
@@ -1,0 +1,166 @@
+# Maple-owned Pages deployments
+
+Maple can publish prebuilt static assets to the existing Cloudflare Pages project
+`maple` (`maple-ca8.pages.dev`). Production remains `trymaple.ai`; its production
+branch remains `pages-production`. This does not move DNS, the `www` marketing
+site, or the updater Worker. The new path does not need a Cloudflare GitHub App.
+Cloudflare supports Wrangler uploads to an existing Git-integrated project after
+automatic builds are disabled; this does not convert the project's type.
+See [Cloudflare's Git integration guidance](https://developers.cloudflare.com/pages/configuration/git-integration/#disable-automatic-deployments).
+
+Merging these workflows does not enable publication. Both repository variables
+`MAPLE_PAGES_PREVIEW_ENABLED` and `MAPLE_PAGES_PRODUCTION_ENABLED` must equal the
+literal string `true` to enable their respective jobs. Missing/false variables
+leave the existing Cloudflare integration and legacy production promoter in use.
+Changing flags, secrets, Cloudflare settings, or production needs an authorized
+operator action; this guide is preparation, not evidence of a completed cutover.
+
+## Build and destination contract
+
+| Source | Configuration profile | Destination |
+| --- | --- | --- |
+| Open internal PR targeting `master` | `pr` | `pr-N` Pages preview |
+| Current `master` push | `pr` | `master` Pages preview |
+| Latest stable Maple release with successful `Release` run | `release` | `pages-production` / `trymaple.ai` |
+
+`Pages preview build` calls `scripts/ci/web.sh` with
+`MAPLE_WEB_ENVIRONMENT=pr` for both PRs and master. It builds the PR head SHA,
+not a production-configured master artifact. A separate unprivileged checkout
+at the workflow/merge SHA supplies manifest tooling for older PR heads.
+Path filters cover the existing web build inputs and the Pages CI files.
+Fork PRs retain ordinary CI but receive no hosted preview. Pushes to other
+branches without a qualifying PR do not get automatic previews from this path.
+
+The fixed build settings come from `scripts/ci/_common.sh`:
+
+| Setting | Preview | Production |
+| --- | --- | --- |
+| OpenSecret API | `https://enclave.secretgpt.ai` | `https://enclave.trymaple.ai` |
+| PCR environment | `development` | `production` |
+| Flags | `https://flags-dev.opensecret.cloud` | `https://flags.opensecret.cloud` |
+| Billing | `https://billing-dev.opensecret.cloud` | `https://billing.opensecret.cloud` |
+
+Both profiles retain the same public client ID. Vite embeds these public values
+at build time; deployment does not substitute Cloudflare dashboard variables.
+Production downloads the existing `maple-web-dist.tar.gz` and `web-final.sha256`
+from the successful stable GitHub release, checks GitHub digests and checksums,
+and uploads those bytes without rebuilding. A master push alone cannot publish
+production. The existing master verification artifact is unchanged.
+
+## Credential and artifact boundaries
+
+The preview build has only `contents: read`, no protected environment, no CF
+secrets, and no restored caches. It uploads exactly the archive and its manifest
+under a name containing the GitHub run ID and attempt. `Publish Pages` executes
+only its trusted default-branch checkout; it never executes PR scripts, installs
+PR dependencies, or loads PR Wrangler configuration. Checkout credentials are
+not persisted and external actions are pinned to commit SHAs. This separation
+addresses the [GitHub Security Lab privileged PR execution pattern](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).
+
+The publisher rechecks repository IDs, workflow ID/path, event, successful run,
+run attempt, source SHA, and the current open internal PR head or master head.
+Production additionally checks the exact stable tag, successful release build,
+reachability from master, latest-release identity, and forward-only production
+ref movement. Superseded sources fail closed, including rerun attempts.
+
+Artifacts remain untrusted data. ZIP/tar parsing bounds compressed and expanded
+bytes, individual file sizes, entries, and paths. It rejects links, special
+files, traversal, duplicates, ambiguous spelling, hidden paths (except the root
+`.well-known` directory used for mobile app links), Functions,
+`_worker.js`, Wrangler/package configuration, `_routes.json`, `_headers`, and
+`_redirects`. Only static files are extracted, including a required `index.html`.
+The publisher rechecks their hashes immediately before upload.
+
+Pinned Wrangler dependencies are installed from trusted `updates/bun.lock`
+with lifecycle scripts disabled, before CF credentials enter the final step.
+Wrangler runs outside the checkout and artifact tree, with no artifact bundling,
+an isolated home, and an allowlisted child environment. It receives CF credentials
+but no GitHub/BWS token, runner command files, inherited Node options, or proxy
+configuration. Its raw output is suppressed and structured results are checked.
+
+A producer can fabricate a manifest alongside an artifact. Hashes and provenance
+prove consistency and authorized origin, not that PR JavaScript is honest or
+uses the declared endpoints. Internal PR review, Access, development accounts,
+and browser smoke remain necessary. Do not enter production credentials into
+an unreviewed preview. The publisher's token boundary is separate from browser
+trust in the application being previewed.
+
+## Operator prerequisites
+
+1. Create GitHub environments `pages-preview` and `pages-production`. Restrict
+   each to the exact **branch** `master` using selected deployment branches/tags;
+   allow no tags, PR refs, or wildcard branches. Protect master review and writes.
+   Configure any required reviewers before placing credentials in the environment.
+2. Create dedicated CI tokens with **Account → Cloudflare Pages → Edit**, limited
+   to the intended CF account. Do not grant DNS, Workers Scripts, or Access
+   permissions, and do not reuse the machine's broader BWS operations token.
+   Set environment secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in
+   each environment. [Cloudflare's CI credential guide](https://developers.cloudflare.com/pages/how-to/use-direct-upload-with-continuous-integration/#generate-an-api-token)
+3. Pages Edit is account-scoped, not restricted to one project or preview branch.
+   Separate preview/production tokens help rotation and auditing but do not create
+   CF project isolation. The trusted publisher enforces its target and branch.
+4. Verify project identity, production branch, current successful production
+   deployment ID/SHA, and Access coverage for `*.maple-ca8.pages.dev`. Record the
+   previous successful production deployment ID in the cutover evidence.
+5. Review branch-protection requirements that expect the Cloudflare App check.
+   The new path reports GitHub deployments, workflow results, and a PR preview
+   comment; it does not impersonate the old Cloudflare App check.
+
+## Staged activation before the repository transfer
+
+1. Run offline validation, then merge the reviewed implementation with both flags
+   absent/false. Retain evidence of the current production deployment.
+2. Enable only `MAPLE_PAGES_PREVIEW_ENABLED=true`. Trigger a current internal PR
+   build and a qualifying master build. Inspect the immutable deployment URLs
+   reported by `Publish Pages`; native previews can still exist during the pilot.
+   Verify Access requires the intended identity, assets load, login/chat work,
+   and browser requests select development API, flags, billing, and PCR history.
+3. In an authorized quiet window, pause releases and wait for existing production
+   writers to finish. In the existing Pages project's branch controls, disable
+   automatic production deployments and set automatic preview deployments to
+   None. Keep `pages-production` as the production branch and preserve domains.
+4. Set `MAPLE_PAGES_PRODUCTION_ENABLED=true`. This disables the legacy
+   `Promote Pages production` job; both paths share the `pages-production`
+   concurrency group. `Publish Pages` refuses a production upload if Cloudflare
+   still reports automatic production deployments enabled.
+5. Manually dispatch `Publish Pages` **from master** to publish the current stable
+   release's existing artifact. No new Release or native rebuild is required.
+   Verify deployment SHA, active canonical deployment ID, production ref, and
+   browser production settings/PCR history; exercise login and chat.
+6. After this evidence passes, amend the organization-move runbook in its owning
+   repository to replace its earlier replacement-project/domain-cutover plan.
+   Transfer separately, then verify the new organization's runner/environment
+   access and publication. This PR does not edit that external runbook or transfer.
+
+## Verification and recovery
+
+CI verifies the Cloudflare deployment's successful stage, environment, project,
+branch, URL, and commit; production also verifies the active canonical deployment.
+It then advances the production ref without force and reports GitHub status.
+That is deployment-state evidence, not an authenticated application smoke test.
+Access-protected previews require a permitted browser; an automated HTTP 403
+alone does not establish a broken application.
+
+GitHub and Cloudflare do not provide an atomic transaction here. If the source
+changes during upload, or later ref/status reporting fails, the new deployment
+can already be active even though the workflow fails. Inspect Cloudflare's actual
+deployment ID, commit and canonical state before retrying. Publish the newly
+eligible source, or use the recorded previous successful **production** deployment
+as an explicitly authorized [Cloudflare rollback target](https://developers.cloudflare.com/pages/configuration/rollbacks/).
+Preview deployments cannot be production rollback targets. Never force-rewind
+`pages-production`, recreate a Release, or change DNS to repair publication.
+
+For a hold, disable the appropriate owned-publisher flag and inspect/drain any
+already running job; a flag change does not cancel an upload in progress. Keep
+native builds disabled while investigating. Disabling the production flag
+reactivates the legacy branch promoter, so native builds must remain off until
+an intentional handback. Never reenable native publishing while the owned
+publisher is enabled. A CF rollback does not change the GitHub release or ref.
+
+Offline checks from the repository root (use the host system for a local check):
+
+```bash
+nix build --no-update-lock-file --no-link --print-build-logs .#checks.x86_64-linux.pages
+nix flake check --no-update-lock-file
+MAPLE_WEB_ENVIRONMENT=pr nix develop --no-update-lock-file .#ci -c ./scripts/ci/web.sh
+```

--- a/flake.nix
+++ b/flake.nix
@@ -629,6 +629,17 @@
               packages = shellPackages;
               shellHook = pathShellHook shellPackages + commonShellHook + linuxShellHook;
             };
+
+          # Trusted Pages publishing uploads static artifacts. It needs no app
+          # toolchain, native setup hooks, or credentials while installing Wrangler.
+          pages =
+            let
+              shellPackages = with pkgs; [ bun nodejs python3 cacert git ];
+            in
+            mkShellForHost {
+              packages = shellPackages;
+              shellHook = pathShellHook shellPackages;
+            };
         }
         // lib.optionalAttrs pkgs.stdenv.isLinux {
           desktop-linux =
@@ -685,6 +696,15 @@
           } ''
             cd "$src"
             python3 scripts/ci/test_change_detection.py
+            touch "$out"
+          '';
+
+          pages = pkgs.runCommand "maple-pages-deployment-check" {
+            nativeBuildInputs = with pkgs; [ python3 yq-go ];
+            src = ./.;
+          } ''
+            cd "$src"
+            python3 -I -m unittest discover -s scripts/ci -p 'test_pages_*.py'
             touch "$out"
           '';
 

--- a/scripts/ci/pages_artifact.py
+++ b/scripts/ci/pages_artifact.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Bound and unpack static Pages artifacts without executing their contents.
+
+The caller must authorize the GitHub repository, workflow, event and run before
+using this module. A manifest and its digest establish consistency, not trust:
+an artifact producer can choose both. Errors intentionally omit artifact data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import struct
+import sys
+import tarfile
+import tempfile
+from typing import BinaryIO
+import unicodedata
+import zipfile
+import zlib
+
+
+ARCHIVE_NAME = "maple-web-dist.tar.gz"
+MANIFEST_NAME = "pages-artifact.json"
+MAX_MANIFEST_BYTES = 16 * 1024
+MAX_ARCHIVE_BYTES = 200 * 1024 * 1024
+MAX_EXPANDED_BYTES = 200 * 1024 * 1024
+MAX_FILE_BYTES = 25 * 1024 * 1024
+MAX_ENTRIES = 20_000
+CHUNK_BYTES = 64 * 1024
+MANIFEST_FIELDS = frozenset(
+    {"schema_version", "profile", "source_sha", "run_id", "run_attempt", "archive_sha256"}
+)
+RESERVED_COMPONENTS = frozenset(
+    {
+        "functions",
+        "_worker.js",
+        "wrangler.toml",
+        "wrangler.json",
+        "wrangler.jsonc",
+        "package.json",
+        "bunfig.toml",
+        "tsconfig.json",
+        "_routes.json",
+        "_headers",
+        "_redirects",
+        ".assetsignore",
+    }
+)
+
+
+class ArtifactError(ValueError):
+    """A safe, fixed-category error; never include producer-controlled text."""
+
+
+def _hex(value: object, length: int) -> bool:
+    return isinstance(value, str) and re.fullmatch(rf"[0-9a-f]{{{length}}}", value) is not None
+
+
+def _positive_integer(value: object) -> bool:
+    return type(value) is int and value > 0
+
+
+def validate_manifest(value: object) -> dict:
+    """Validate the complete manifest, including strict types and unknown keys."""
+    if not isinstance(value, dict) or set(value) != MANIFEST_FIELDS:
+        raise ArtifactError("Invalid artifact manifest fields")
+    if type(value["schema_version"]) is not int or value["schema_version"] != 1:
+        raise ArtifactError("Unsupported artifact manifest version")
+    if value["profile"] not in ("pr", "release"):
+        raise ArtifactError("Invalid artifact build profile")
+    if not _hex(value["source_sha"], 40) or not _hex(value["archive_sha256"], 64):
+        raise ArtifactError("Invalid artifact digest or source identity")
+    if not _positive_integer(value["run_id"]) or not _positive_integer(value["run_attempt"]):
+        raise ArtifactError("Invalid artifact run identity")
+    return dict(value)
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ArtifactError("Duplicate artifact manifest field")
+        result[key] = value
+    return result
+
+
+def _load_manifest(data: bytes) -> dict:
+    if len(data) > MAX_MANIFEST_BYTES:
+        raise ArtifactError("Artifact manifest exceeds size limit")
+    try:
+        value = json.loads(data, object_pairs_hook=_unique_object)
+    except (UnicodeError, json.JSONDecodeError, RecursionError, ValueError):
+        raise ArtifactError("Invalid artifact manifest encoding") from None
+    return validate_manifest(value)
+
+
+def _copy_bounded(source: BinaryIO, target: BinaryIO | None, limit: int) -> str:
+    digest = hashlib.sha256()
+    count = 0
+    while chunk := source.read(min(CHUNK_BYTES, limit - count + 1)):
+        count += len(chunk)
+        if count > limit:
+            raise ArtifactError("Artifact exceeds size limit")
+        digest.update(chunk)
+        if target is not None:
+            target.write(chunk)
+    return digest.hexdigest()
+
+
+def _open_regular(path: Path) -> BinaryIO:
+    # The isolated deployment job owns paths; refuse symlinks and special files
+    # even when a caller accidentally points this at an unexpected local path.
+    descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise ArtifactError("Artifact input is not a regular file")
+    return os.fdopen(descriptor, "rb")
+
+
+def pack_manifest(archive: Path, profile: str, sha: str, run_id: int, run_attempt: int) -> dict:
+    manifest = validate_manifest(
+        {
+            "schema_version": 1,
+            "profile": profile,
+            "source_sha": sha,
+            "run_id": run_id,
+            "run_attempt": run_attempt,
+            "archive_sha256": "0" * 64,
+        }
+    )
+    try:
+        with _open_regular(archive) as source:
+            manifest["archive_sha256"] = _copy_bounded(source, None, MAX_ARCHIVE_BYTES)
+    except OSError:
+        raise ArtifactError("Cannot read artifact archive") from None
+    return manifest
+
+
+def read_preview_zip(
+    path: Path,
+    expected_sha: str,
+    expected_run_id: int,
+    expected_run_attempt: int,
+    output_archive: Path,
+) -> dict:
+    """Unwrap precisely the two expected GitHub artifact files, without extraction."""
+    if not _hex(expected_sha, 40) or not all(
+        _positive_integer(value) for value in (expected_run_id, expected_run_attempt)
+    ):
+        raise ArtifactError("Invalid expected artifact identity")
+    staged: Path | None = None
+    try:
+        with _open_regular(path) as source:
+            # Bound the central directory before ZipFile reads it into memory.
+            if os.fstat(source.fileno()).st_size > MAX_ARCHIVE_BYTES + MAX_MANIFEST_BYTES + 4096:
+                raise ArtifactError("Artifact ZIP exceeds size limit")
+            _check_zip_directory(source)
+            with zipfile.ZipFile(source) as bundle:
+                entries = bundle.infolist()
+                if len(entries) != 2 or {entry.filename for entry in entries} != {
+                    ARCHIVE_NAME,
+                    MANIFEST_NAME,
+                }:
+                    raise ArtifactError("Unexpected artifact ZIP entries")
+                for entry in entries:
+                    unix_type = stat.S_IFMT(entry.external_attr >> 16)
+                    if (
+                        entry.is_dir()
+                        or entry.orig_filename != entry.filename
+                        or entry.external_attr & 0x10
+                        or unix_type not in (0, stat.S_IFREG)
+                        or entry.flag_bits & 1
+                        or entry.compress_type not in (zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED)
+                    ):
+                        raise ArtifactError("Unsupported artifact ZIP entry")
+                    limit = MAX_MANIFEST_BYTES if entry.filename == MANIFEST_NAME else MAX_ARCHIVE_BYTES
+                    if entry.file_size > limit:
+                        raise ArtifactError("Artifact ZIP entry exceeds size limit")
+                manifest = _load_manifest(bundle.read(MANIFEST_NAME))
+                if (
+                    manifest["profile"] != "pr"
+                    or manifest["source_sha"] != expected_sha
+                    or manifest["run_id"] != expected_run_id
+                    or manifest["run_attempt"] != expected_run_attempt
+                ):
+                    raise ArtifactError("Artifact identity does not match authorized preview")
+                if output_archive.exists() or output_archive.is_symlink():
+                    raise ArtifactError("Artifact output already exists")
+                descriptor, name = tempfile.mkstemp(prefix=".pages-archive-", dir=output_archive.parent)
+                staged = Path(name)
+                with os.fdopen(descriptor, "wb") as target, bundle.open(ARCHIVE_NAME) as archive:
+                    actual_digest = _copy_bounded(archive, target, MAX_ARCHIVE_BYTES)
+                if actual_digest != manifest["archive_sha256"]:
+                    raise ArtifactError("Artifact archive digest mismatch")
+                # A hard link publishes without overwriting an existing path.
+                os.link(staged, output_archive)
+                staged.unlink()
+                staged = None
+                return manifest
+    except (OSError, EOFError, RuntimeError, zipfile.BadZipFile, NotImplementedError, zlib.error):
+        raise ArtifactError("Cannot read artifact ZIP") from None
+    finally:
+        if staged is not None:
+            staged.unlink(missing_ok=True)
+
+
+def _check_zip_directory(source: BinaryIO) -> None:
+    # The artifact has exactly two small central-directory entries. Inspect the
+    # fixed-size end record before ZipFile allocates its list of entries. ZIP64
+    # and multipart archives are unnecessary below the 200 MiB artifact limit.
+    size = os.fstat(source.fileno()).st_size
+    source.seek(max(0, size - 65_557))
+    tail = source.read(65_557)
+    offset = tail.rfind(b"PK\x05\x06")
+    if offset < 0 or len(tail) - offset < 22:
+        raise ArtifactError("Invalid artifact ZIP directory")
+    _, disk, directory_disk, disk_entries, entries, directory_size, directory_offset, comment_size = struct.unpack(
+        "<4s4H2LH", tail[offset : offset + 22]
+    )
+    end_offset = max(0, size - 65_557) + offset
+    if (
+        disk != 0
+        or directory_disk != 0
+        or disk_entries != 2
+        or entries != 2
+        or directory_size > 4096
+        or directory_offset + directory_size != end_offset
+        or offset + 22 + comment_size != len(tail)
+    ):
+        raise ArtifactError("Unexpected artifact ZIP directory")
+    source.seek(0)
+
+
+class _ExpandedReader:
+    """Bound all decompressed tar bytes, including extension headers and padding."""
+
+    def __init__(self, source: BinaryIO) -> None:
+        self.source = source
+        self.count = 0
+
+    def read(self, size: int = -1) -> bytes:
+        remaining = MAX_EXPANDED_BYTES - self.count
+        data = self.source.read(min(size if size >= 0 else remaining + 1, remaining + 1))
+        self.count += len(data)
+        if self.count > MAX_EXPANDED_BYTES:
+            raise ArtifactError("Expanded artifact exceeds size limit")
+        return data
+
+
+def _static_path(name: str, *, is_directory: bool = False) -> str:
+    if name.startswith("./"):
+        name = name[2:]
+    # Trailing slash is the conventional tar directory spelling. Every other
+    # path component must be literal, unambiguous and safe on Linux and macOS.
+    name = name.removesuffix("/")
+    if (
+        not name
+        or name.startswith("/")
+        or "\\" in name
+        or ":" in name
+        or any(unicodedata.category(character).startswith("C") for character in name)
+        or unicodedata.normalize("NFC", name) != name
+        or len(name.encode("utf-8")) > 4096
+    ):
+        raise ArtifactError("Unsafe static artifact path")
+    parts = name.split("/")
+    if any(
+        not part
+        # Mobile association documents live in this standard public directory.
+        # The exception applies only to its exact root spelling, never another
+        # dot-prefixed component or a regular file named .well-known.
+        or (
+            part.startswith(".")
+            and not (
+                index == 0
+                and part == ".well-known"
+                and (len(parts) > 1 or is_directory)
+            )
+        )
+        or len(part.encode("utf-8")) > 255
+        or part.casefold() in RESERVED_COMPONENTS
+        for index, part in enumerate(parts)
+    ):
+        raise ArtifactError("Forbidden static artifact path")
+    return name
+
+
+def extract_static(archive: Path, destination: Path, expected_digest: str) -> dict[str, str]:
+    """Verify and manually extract static-only files into a new or empty directory.
+
+    Returns relative file paths mapped to SHA-256 values. Never execute or
+    interpret JavaScript, HTML, configuration, archive modes or ownership.
+    Failed validation leaves the requested destination untouched.
+    """
+    if not _hex(expected_digest, 64):
+        raise ArtifactError("Invalid expected artifact digest")
+    staged: Path | None = None
+    try:
+        if destination.is_symlink() or (
+            destination.exists() and (not destination.is_dir() or any(destination.iterdir()))
+        ):
+            raise ArtifactError("Static destination must be new or empty")
+        with _open_regular(archive) as source:
+            if _copy_bounded(source, None, MAX_ARCHIVE_BYTES) != expected_digest:
+                raise ArtifactError("Artifact archive digest mismatch")
+            source.seek(0)
+            staged = Path(tempfile.mkdtemp(prefix=".pages-static-", dir=destination.parent))
+            hashes: dict[str, str] = {}
+            seen: set[str] = set()
+            spellings: dict[str, str] = {}
+            entries = 0
+            with gzip.GzipFile(fileobj=source) as compressed:
+                expanded = _ExpandedReader(compressed)
+                with tarfile.open(fileobj=expanded, mode="r|") as bundle:
+                    for member in bundle:
+                        entries += 1
+                        if entries > MAX_ENTRIES:
+                            raise ArtifactError("Static artifact has too many entries")
+                        if (
+                            not (member.isdir() or member.isreg())
+                            or member.issparse()
+                            or any(key.startswith("GNU.sparse") for key in member.pax_headers)
+                            or member.size < 0
+                            or member.size > MAX_FILE_BYTES
+                            or (member.isdir() and member.size != 0)
+                            or (not member.isdir() and member.name.endswith("/"))
+                        ):
+                            raise ArtifactError("Unsupported static artifact entry")
+                        name = _static_path(member.name, is_directory=member.isdir())
+                        if name in seen:
+                            raise ArtifactError("Duplicate static artifact path")
+                        seen.add(name)
+                        parts = name.split("/")
+                        for index in range(1, len(parts) + 1):
+                            prefix = "/".join(parts[:index])
+                            folded = prefix.casefold()
+                            if folded in spellings and spellings[folded] != prefix:
+                                raise ArtifactError("Conflicting static artifact path spelling")
+                            spellings[folded] = prefix
+                        target = staged.joinpath(*parts)
+                        target.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+                        if member.isdir():
+                            target.mkdir(mode=0o755, exist_ok=True)
+                        else:
+                            payload = bundle.extractfile(member)
+                            if payload is None:
+                                raise ArtifactError("Missing static artifact file data")
+                            descriptor = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o644)
+                            with os.fdopen(descriptor, "wb") as output, payload:
+                                hashes[name] = _copy_bounded(payload, output, MAX_FILE_BYTES)
+                            if target.stat().st_size != member.size:
+                                raise ArtifactError("Truncated static artifact file")
+                            target.chmod(0o644)
+                # tar ends before gzip; check the trailer and bound any remaining
+                # decompressed data so padding cannot hide a compression bomb.
+                while expanded.read(CHUNK_BYTES):
+                    pass
+            if "index.html" not in hashes:
+                raise ArtifactError("Static artifact is missing root index.html")
+            for root, directories, _ in os.walk(staged):
+                Path(root).chmod(0o755)
+                for directory in directories:
+                    (Path(root) / directory).chmod(0o755)
+            os.rename(staged, destination)
+            staged = None
+            return hashes
+    except (OSError, EOFError, tarfile.TarError, RecursionError, UnicodeError, zlib.error):
+        raise ArtifactError("Cannot unpack static artifact") from None
+    finally:
+        if staged is not None:
+            shutil.rmtree(staged)
+
+
+def main() -> int:
+    class SafeArgumentParser(argparse.ArgumentParser):
+        def error(self, message: str) -> None:
+            self.exit(2, "Invalid Pages artifact command arguments\n")
+
+    parser = SafeArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    manifest = commands.add_parser("manifest", help="Write metadata for a built web archive")
+    manifest.add_argument("--archive", required=True, type=Path)
+    manifest.add_argument("--profile", required=True, choices=("pr", "release"))
+    manifest.add_argument("--sha", required=True)
+    manifest.add_argument("--run-id", required=True, type=int)
+    manifest.add_argument("--run-attempt", required=True, type=int)
+    manifest.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        value = pack_manifest(args.archive, args.profile, args.sha, args.run_id, args.run_attempt)
+        args.output.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+    except (ArtifactError, OSError):
+        print("Cannot create Pages artifact manifest", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/pages_deploy.py
+++ b/scripts/ci/pages_deploy.py
@@ -88,11 +88,12 @@ class API:
         require(len(body) <= 8 * 1024 * 1024, "API response exceeds limit")
         return json.loads(body)
 
-    def download(self, path, destination, limit=MAX_DOWNLOAD, expected_size=None, expected_digest=None):
+    def download(self, path, destination, limit=MAX_DOWNLOAD, expected_size=None, expected_digest=None,
+                 accept="application/octet-stream"):
         # Only the constructed GitHub API endpoint receives Authorization.
         # GitHub asset redirects are signed URLs; never forward the token to them.
         try:
-            response = self.request(path, accept="application/octet-stream")
+            response = self.request(path, accept=accept)
         except HTTPError as error:
             require(error.code in {301, 302, 303, 307, 308}, "Artifact download rejected")
             url = error.headers.get("Location", "")
@@ -242,7 +243,7 @@ def prepare(gh, event, target, state):
     if target == "preview":
         zipped = state / "artifact.zip"
         gh.api.download(gh.root + f"/actions/artifacts/{plan['artifact_id']}/zip", zipped,
-                        expected_digest=plan["artifact_digest"])
+                        expected_digest=plan["artifact_digest"], accept="application/vnd.github+json")
         manifest = read_preview_zip(zipped, plan["sha"], plan["run_id"], plan["run_attempt"], archive)
         archive_digest = manifest["archive_sha256"]
     else:

--- a/scripts/ci/pages_deploy.py
+++ b/scripts/ci/pages_deploy.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Publish verified static artifacts using trusted default-branch code only.
+
+The build workflow is unprivileged. Its archive is data, never configuration or
+executable code on this runner. See docs/pages-deployments.md for the threat model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+# -I discards PYTHONPATH and the working directory. This is the trusted checkout.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from pages_artifact import extract_static, read_preview_zip  # noqa: E402
+
+PROJECT = "maple"
+SUBDOMAIN = "maple-ca8.pages.dev"
+PRODUCTION_BRANCH = "pages-production"
+PREVIEW_WORKFLOW = "pages-preview-build.yml"
+RELEASE_WORKFLOW = "release.yml"
+MAX_DOWNLOAD = 200 * 1024 * 1024
+
+
+class Rejected(ValueError):
+    """Category-only message: never echo attacker-controlled input or API bodies."""
+
+
+class Superseded(Rejected):
+    """A once eligible deployment no longer owns its target."""
+
+
+def require(condition, message):
+    if not condition:
+        raise Rejected(message)
+
+
+def number(value):
+    require(type(value) is int and value > 0, "Invalid numeric identifier")
+    return value
+
+
+def sha(value):
+    require(isinstance(value, str) and re.fullmatch(r"[0-9a-f]{40}", value), "Invalid source SHA")
+    return value
+
+
+def digest(value):
+    require(isinstance(value, str) and re.fullmatch(r"sha256:[0-9a-f]{64}", value), "Missing GitHub asset digest")
+    return value.removeprefix("sha256:")
+
+
+class NoRedirect(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+class API:
+    def __init__(self, base, token):
+        require(bool(token), "Required API credential is not configured")
+        self.base, self.token = base, token
+        self.opener = build_opener(NoRedirect)
+
+    def request(self, path, method="GET", data=None, accept="application/vnd.github+json"):
+        require(path.startswith("/") and not path.startswith("//"), "Invalid API path")
+        headers = {"Authorization": f"Bearer {self.token}", "Accept": accept,
+                   "User-Agent": "Maple-Pages-publisher", "X-GitHub-Api-Version": "2022-11-28"}
+        body = None if data is None else json.dumps(data).encode()
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+        return self.opener.open(Request(self.base + path, data=body, headers=headers, method=method), timeout=60)
+
+    def json(self, path, method="GET", data=None):
+        with self.request(path, method, data) as response:
+            body = response.read(8 * 1024 * 1024 + 1)
+        require(len(body) <= 8 * 1024 * 1024, "API response exceeds limit")
+        return json.loads(body)
+
+    def download(self, path, destination, limit=MAX_DOWNLOAD, expected_size=None, expected_digest=None):
+        # Only the constructed GitHub API endpoint receives Authorization.
+        # GitHub asset redirects are signed URLs; never forward the token to them.
+        try:
+            response = self.request(path, accept="application/octet-stream")
+        except HTTPError as error:
+            require(error.code in {301, 302, 303, 307, 308}, "Artifact download rejected")
+            url = error.headers.get("Location", "")
+            error.close()
+            for _ in range(5):
+                parsed = urlsplit(url)
+                require(parsed.scheme == "https" and parsed.hostname and not parsed.username
+                        and not parsed.password and parsed.port in {None, 443}, "Invalid artifact redirect")
+                try:
+                    response = self.opener.open(Request(url, headers={"User-Agent": "Maple-Pages-publisher"}), timeout=60)
+                    break
+                except HTTPError as redirected:
+                    require(redirected.code in {301, 302, 303, 307, 308}, "Artifact redirect rejected")
+                    url = redirected.headers.get("Location", "")
+                    redirected.close()
+            else:
+                raise Rejected("Too many artifact redirects")
+        size, hasher = 0, hashlib.sha256()
+        with response, destination.open("xb") as output:
+            while chunk := response.read(1024 * 1024):
+                size += len(chunk)
+                require(size <= limit, "Artifact exceeds download limit")
+                hasher.update(chunk)
+                output.write(chunk)
+        require(expected_size is None or size == expected_size, "Artifact size mismatch")
+        require(expected_digest is None or hasher.hexdigest() == expected_digest, "Artifact digest mismatch")
+
+
+class GitHub:
+    def __init__(self, api, repository, repository_id):
+        require(re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository), "Invalid repository")
+        self.api, self.repository = api, repository
+        self.repository_id = number(repository_id)
+        self.root = "/repos/" + repository
+
+    def get(self, path):
+        return self.api.json(self.root + path)
+
+    def write(self, path, data, method="POST"):
+        return self.api.json(self.root + path, method, data)
+
+    def run(self, run_id, workflow, event, attempt=None):
+        run = self.get(f"/actions/runs/{number(run_id)}")
+        expected_workflow = self.get(f"/actions/workflows/{workflow}")
+        require(run["repository"]["id"] == self.repository_id
+                and run["head_repository"]["id"] == self.repository_id, "Foreign repository run")
+        require(run["workflow_id"] == expected_workflow["id"]
+                and run["path"] == f".github/workflows/{workflow}", "Unexpected build workflow")
+        require(run["event"] == event and run["status"] == "completed"
+                and run["conclusion"] == "success", "Build has not succeeded")
+        if attempt is not None and run["run_attempt"] != number(attempt):
+            raise Superseded("Build attempt was superseded")
+        number(run["run_attempt"])
+        sha(run["head_sha"])
+        return run
+
+
+def preview_plan(gh, event):
+    trigger = event["workflow_run"]
+    require(trigger["event"] in {"pull_request", "push"}, "Unexpected preview event")
+    run = gh.run(trigger["id"], PREVIEW_WORKFLOW, trigger["event"], trigger["run_attempt"])
+    require(run["head_sha"] == trigger["head_sha"], "Trigger SHA mismatch")
+    pr_number = None
+    if run["event"] == "push":
+        require(run["head_branch"] == "master", "Unexpected preview branch")
+        if gh.get("/git/ref/heads/master")["object"]["sha"] != run["head_sha"]:
+            raise Superseded("Master preview was superseded")
+        branch = "master"
+    else:
+        # workflow_run.pull_requests can be empty. Ask GitHub for PRs associated
+        # with this exact commit, then independently validate the current head.
+        candidates = gh.get(f"/commits/{run['head_sha']}/pulls?per_page=100")
+        matches = []
+        for candidate in candidates:
+            pr = gh.get(f"/pulls/{number(candidate['number'])}")
+            if (pr["state"] == "open" and pr["base"]["ref"] == "master"
+                    and pr["base"]["repo"]["id"] == gh.repository_id
+                    and pr["head"].get("repo") and pr["head"]["repo"]["id"] == gh.repository_id
+                    and pr["head"]["sha"] == run["head_sha"]
+                    and pr["head"]["ref"] == run["head_branch"]):
+                matches.append(pr)
+        if not matches:
+            raise Superseded("No current internal PR owns this preview")
+        require(len(matches) == 1, "Ambiguous preview PR")
+        pr_number = number(matches[0]["number"])
+        branch = f"pr-{pr_number}"
+    artifact_name = f"maple-pages-preview-{run['id']}-{run['run_attempt']}"
+    artifacts = gh.get(f"/actions/runs/{run['id']}/artifacts?per_page=100")
+    require(artifacts["total_count"] <= 100, "Too many build artifacts")
+    matches = [a for a in artifacts["artifacts"] if a["name"] == artifact_name and not a["expired"]]
+    require(len(matches) == 1, "Expected one preview artifact from this attempt")
+    artifact = matches[0]
+    require(0 < artifact["size_in_bytes"] <= MAX_DOWNLOAD, "Preview artifact size invalid")
+    return {"target": "preview", "profile": "pr", "sha": run["head_sha"], "branch": branch,
+            "pr_number": pr_number, "run_id": number(run["id"]), "run_attempt": run["run_attempt"],
+            "artifact_id": number(artifact["id"]), "artifact_digest": digest(artifact["digest"])}
+
+
+def release_asset(release, name):
+    matches = [a for a in release["assets"] if a["name"] == name and a["state"] == "uploaded"]
+    require(len(matches) == 1, "Expected one release asset")
+    asset = matches[0]
+    require(type(asset["size"]) is int and 0 < asset["size"] <= MAX_DOWNLOAD, "Release asset size invalid")
+    return {"id": number(asset["id"]), "size": asset["size"], "digest": digest(asset["digest"])}
+
+
+def production_plan(gh, event):
+    release = gh.get("/releases/latest")
+    require(not release["draft"] and not release["prerelease"], "Release is not stable")
+    tag = release["tag_name"]
+    require(re.fullmatch(r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", tag), "Invalid stable release tag")
+    release_sha = sha(gh.get(f"/commits/{tag}")["sha"])
+    if "workflow_run" in event:
+        trigger = event["workflow_run"]
+        if trigger["head_branch"] != tag:
+            raise Superseded("Release is no longer the latest stable release")
+        run = gh.run(trigger["id"], RELEASE_WORKFLOW, "release", trigger["run_attempt"])
+    else:
+        runs = gh.get(f"/actions/workflows/{RELEASE_WORKFLOW}/runs?event=release&head_sha={release_sha}&per_page=100")
+        candidates = [r for r in runs["workflow_runs"] if r["head_branch"] == tag]
+        require(bool(candidates), "No release build exists for this stable release")
+        run = gh.run(candidates[0]["id"], RELEASE_WORKFLOW, "release")
+    require(run["head_sha"] == release_sha and run["head_branch"] == tag, "Release build SHA mismatch")
+    require(gh.get(f"/compare/{release_sha}...master")["status"] in {"ahead", "identical"}, "Release is not on master")
+    current_sha = sha(gh.get(f"/git/ref/heads/{PRODUCTION_BRANCH}")["object"]["sha"])
+    if current_sha != release_sha:
+        require(gh.get(f"/compare/{current_sha}...{release_sha}")["status"] == "ahead", "Non-forward production change")
+    return {"target": "production", "profile": "release", "sha": release_sha, "branch": PRODUCTION_BRANCH,
+            "release_id": number(release["id"]), "release_tag": tag, "previous_sha": current_sha,
+            "run_id": number(run["id"]), "run_attempt": run["run_attempt"],
+            "archive": release_asset(release, "maple-web-dist.tar.gz"),
+            "checksum": release_asset(release, "web-final.sha256")}
+
+
+def select_plan(gh, event, target):
+    repo = gh.get("")
+    require(repo["id"] == gh.repository_id and repo["default_branch"] == "master", "Unexpected repository identity")
+    require(target in {"preview", "production"}, "Invalid deployment target")
+    return preview_plan(gh, event) if target == "preview" else production_plan(gh, event)
+
+
+def prepare(gh, event, target, state):
+    require(not state.exists(), "Deployment state already exists")
+    state.mkdir(mode=0o700, parents=False)
+    plan = select_plan(gh, event, target)
+    archive = state / "web.tar.gz"
+    if target == "preview":
+        zipped = state / "artifact.zip"
+        gh.api.download(gh.root + f"/actions/artifacts/{plan['artifact_id']}/zip", zipped,
+                        expected_digest=plan["artifact_digest"])
+        manifest = read_preview_zip(zipped, plan["sha"], plan["run_id"], plan["run_attempt"], archive)
+        archive_digest = manifest["archive_sha256"]
+    else:
+        for key, path in (("archive", archive), ("checksum", state / "web.sha256")):
+            asset = plan[key]
+            gh.api.download(gh.root + f"/releases/assets/{asset['id']}", path,
+                            limit=MAX_DOWNLOAD if key == "archive" else 4096,
+                            expected_size=asset["size"], expected_digest=asset["digest"])
+        archive_digest = plan["archive"]["digest"]
+        checksum = (state / "web.sha256").read_text()
+        require(re.fullmatch(re.escape(archive_digest) + r"  (?:frontend/src-tauri/target/reproducibility/)?maple-web-dist\.tar\.gz\n?", checksum),
+                "Release checksum manifest mismatch")
+    files = extract_static(archive, state / "assets", archive_digest)
+    (state / "plan.json").write_text(json.dumps({"selection": plan, "archive_digest": archive_digest, "files": files}))
+    return plan
+
+
+def cloudflare_project(cf, account, target):
+    project = cf.json(f"/accounts/{account}/pages/projects/{PROJECT}")
+    require(project.get("success") is True, "Cloudflare project lookup failed")
+    project = project["result"]
+    require(project["name"] == PROJECT and project["subdomain"] == SUBDOMAIN
+            and project["production_branch"] == PRODUCTION_BRANCH, "Cloudflare project identity mismatch")
+    if target == "production":
+        require(project.get("source", {}).get("config", {}).get("production_deployments_enabled") is False,
+                "Disable Cloudflare automatic production builds before enabling the publisher")
+    return project
+
+
+def wrangler_environment(account, token, workdir):
+    require(re.fullmatch(r"[0-9a-f]{32}", account), "Invalid Cloudflare account ID")
+    require(bool(token), "Cloudflare deployment token is not configured")
+    # No GH token, runner command files, NODE_OPTIONS, Bun/npm configuration,
+    # proxies, inherited CF overrides, agent hints or parent home directory.
+    environment = {"PATH": os.environ["PATH"], "HOME": str(workdir / "home"),
+                   "TMPDIR": str(workdir / "tmp"), "CI": "true", "NO_COLOR": "1",
+                   "CLOUDFLARE_ACCOUNT_ID": account, "CLOUDFLARE_API_TOKEN": token,
+                   "WRANGLER_SEND_METRICS": "false", "WRANGLER_LOG_LEVEL": "error",
+                   "WRANGLER_OUTPUT_FILE_PATH": str(workdir / "wrangler.jsonl")}
+    for name in ("SSL_CERT_FILE", "NIX_SSL_CERT_FILE"):
+        if name in os.environ:
+            environment[name] = os.environ[name]
+    (workdir / "home").mkdir()
+    (workdir / "tmp").mkdir()
+    return environment
+
+
+def require_clean_wrangler_ancestors(workdir):
+    # Wrangler searches above cwd for project/configuration files. The artifact
+    # is a sibling, and even an unexpected runner-level config must fail closed.
+    for directory in (workdir, *workdir.parents):
+        for name in ("wrangler.toml", "wrangler.json", "wrangler.jsonc", ".wrangler",
+                     "package.json", "functions", ".env", ".env.local", ".dev.vars"):
+            require(not (directory / name).exists() and not (directory / name).is_symlink(),
+                    "Unexpected deployment configuration above Wrangler working directory")
+
+
+def run_wrangler(plan, assets, account, token, workdir):
+    root = Path(__file__).resolve().parents[2]
+    executable = root / "updates/node_modules/wrangler/bin/wrangler.js"
+    require(executable.is_file(), "Pinned Wrangler is not installed")
+    node = shutil.which("node")
+    require(node is not None, "Pinned Node runtime is not available")
+    require_clean_wrangler_ancestors(workdir)
+    environment = wrangler_environment(account, token, workdir)
+    command = [node, str(executable), "pages", "deploy", str(assets), "--project-name", PROJECT,
+               "--branch", plan["branch"], "--commit-hash", plan["sha"], "--commit-dirty=false",
+               "--commit-message", f"Maple {plan['profile']} {plan['sha']}", "--no-bundle"]
+    # Never echo Wrangler output: remote errors and artifact names are untrusted.
+    subprocess.run(command, cwd=workdir, env=environment, stdin=subprocess.DEVNULL,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True, timeout=900)
+    output = workdir / "wrangler.jsonl"
+    require(output.is_file() and output.stat().st_size < 1024 * 1024, "Missing Wrangler result")
+    results = [json.loads(line) for line in output.read_text().splitlines()]
+    results = [result for result in results if result.get("type") == "pages-deploy-detailed"]
+    require(len(results) == 1, "Unexpected Wrangler result")
+    result = results[0]
+    require(result["pages_project"] == PROJECT and result["environment"] == plan["target"]
+            and result["deployment_trigger"]["metadata"]["commit_hash"] == plan["sha"], "Wrangler deployment mismatch")
+    require(re.fullmatch(r"[0-9a-f-]{36}", result["deployment_id"]), "Invalid deployment ID")
+    require(re.fullmatch(r"https://[0-9a-f]{8}\." + re.escape(SUBDOMAIN), result["url"]), "Unexpected deployment URL")
+    return result
+
+
+def verify_deployment(cf, account, plan, result):
+    path = f"/accounts/{account}/pages/projects/{PROJECT}"
+    for _ in range(30):
+        response = cf.json(path + f"/deployments/{result['deployment_id']}")
+        require(response.get("success") is True, "Cloudflare deployment lookup failed")
+        deployment = response["result"]
+        require(deployment["environment"] == plan["target"] and deployment["project_name"] == PROJECT
+                and deployment["url"] == result["url"]
+                and deployment["deployment_trigger"]["metadata"]["commit_hash"] == plan["sha"]
+                and deployment["deployment_trigger"]["metadata"]["branch"] == plan["branch"], "Cloudflare deployment mismatch")
+        if (deployment["latest_stage"]["name"] == "deploy"
+                and deployment["latest_stage"]["status"] == "success"):
+            if plan["target"] == "preview":
+                return
+            project = cloudflare_project(cf, account, "production")
+            if project["canonical_deployment"]["id"] == result["deployment_id"]:
+                return
+        require(deployment["latest_stage"]["status"] not in {"failure", "canceled"}, "Cloudflare deployment failed")
+        time.sleep(2)
+    raise Rejected("Cloudflare deployment did not become active")
+
+
+def report(gh, plan, result):
+    environment = "pages-production" if plan["target"] == "production" else f"pages-{plan['branch']}"
+    deployment = gh.write("/deployments", {"ref": plan["sha"], "environment": environment,
+                          "auto_merge": False, "required_contexts": [], "transient_environment": plan["target"] == "preview",
+                          "production_environment": plan["target"] == "production",
+                          "description": "Verified static Pages artifact"})
+    public_url = "https://trymaple.ai" if plan["target"] == "production" else result["url"]
+    gh.write(f"/deployments/{number(deployment['id'])}/statuses", {"state": "success", "environment_url": public_url,
+             "description": "Cloudflare deployment verified; application smoke is separate", "auto_inactive": True})
+    if plan.get("pr_number"):
+        # A small comment update uses only validated numbers, SHA and Cloudflare URL.
+        marker = "<!-- maple-pages-preview -->"
+        body = f"{marker}\nMaple development preview: {result['url']}\n\nCommit: `{plan['sha']}`\n\nUses development API, billing, flags and PCR configuration. Cloudflare Access applies."
+        comments = gh.get(f"/issues/{plan['pr_number']}/comments?per_page=100")
+        own = [c for c in comments if c["user"]["login"] == "github-actions[bot]" and c["body"].startswith(marker)]
+        if own:
+            gh.write(f"/issues/comments/{number(own[-1]['id'])}", {"body": body}, "PATCH")
+        else:
+            gh.write(f"/issues/{plan['pr_number']}/comments", {"body": body})
+
+
+def deploy(gh, event, state):
+    saved = json.loads((state / "plan.json").read_text())
+    plan = saved["selection"]
+    if select_plan(gh, event, plan["target"]) != plan:
+        raise Superseded("Deployment selection changed before upload")
+    account, token = os.environ.get("CLOUDFLARE_ACCOUNT_ID", ""), os.environ.get("CLOUDFLARE_API_TOKEN", "")
+    require(re.fullmatch(r"[0-9a-f]{32}", account), "Invalid Cloudflare account ID")
+    cf = API("https://api.cloudflare.com/client/v4", token)
+    cloudflare_project(cf, account, plan["target"])
+    # Re-extract under a new directory; no cache or previously extracted files
+    # can alter what the credential-bearing Wrangler process sees.
+    with tempfile.TemporaryDirectory(prefix="maple-pages-upload-", dir=state.parent) as temp:
+        workspace = Path(temp)
+        files = extract_static(state / "web.tar.gz", workspace / "assets", saved["archive_digest"])
+        require(files == saved["files"], "Prepared artifact changed")
+        workdir = workspace / "runner"
+        workdir.mkdir()
+        result = run_wrangler(plan, workspace / "assets", account, token, workdir)
+        verify_deployment(cf, account, plan, result)
+    if plan["target"] == "production":
+        if select_plan(gh, event, "production") != plan:
+            raise Superseded("Release changed during deployment; inspect the deployed result")
+        if plan["previous_sha"] != plan["sha"]:
+            updated = gh.write(f"/git/refs/heads/{PRODUCTION_BRANCH}", {"sha": plan["sha"], "force": False}, "PATCH")
+            require(updated["object"]["sha"] == plan["sha"], "Production ref update failed")
+    else:
+        if select_plan(gh, event, "preview") != plan:
+            raise Superseded("Preview changed during deployment; a newer preview is required")
+    report(gh, plan, result)
+    summary = (f"### Maple Pages {plan['target']}\n\n"
+               f"- Source: `{plan['sha']}`; profile: `{plan['profile']}`.\n"
+               f"- Deployment: {result['url']}\n"
+               f"- Cloudflare deployment ID: `{result['deployment_id']}`.\n"
+               "- Verified Cloudflare deployment state and commit; production also verifies the active deployment.\n"
+               "- Login, chat, browser configuration and Access behavior require separate application smoke checks.\n")
+    if os.environ.get("GITHUB_STEP_SUMMARY"):
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as output:
+            output.write(summary)
+    print(f"Verified Pages {plan['target']} deployment for {plan['sha']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["prepare", "deploy"])
+    parser.add_argument("--target", choices=["preview", "production"])
+    parser.add_argument("--state", type=Path, required=True)
+    args = parser.parse_args()
+    require(os.environ.get("GITHUB_REF") == "refs/heads/master", "Publisher must run from protected master")
+    require(os.environ.get("GITHUB_EVENT_NAME") in {"workflow_run", "workflow_dispatch"}, "Unexpected publisher event")
+    checkout_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    require(checkout_sha == sha(os.environ.get("GITHUB_SHA")), "Publisher checkout must be the trusted workflow SHA")
+    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+    require((os.environ["GITHUB_EVENT_NAME"] == "workflow_run") == ("workflow_run" in event), "Publisher event mismatch")
+    gh = GitHub(API("https://api.github.com", os.environ.get("GH_TOKEN", "")),
+                os.environ["GITHUB_REPOSITORY"], int(os.environ["GITHUB_REPOSITORY_ID"]))
+    state = args.state.resolve()
+    require(state.parent == Path(os.environ["RUNNER_TEMP"]).resolve(), "State must be outside the checkout in runner temp")
+    if args.command == "prepare":
+        require(args.target is not None, "Deployment target is required")
+        prepare(gh, event, args.target, state)
+    else:
+        deploy(gh, event, state)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Superseded as error:
+        print(f"Pages deployment skipped: {error}")
+        # Stop later steps as well; rerun from the newest source instead.
+        sys.exit(1)
+    except (Rejected, ValueError, KeyError, TypeError, OSError, HTTPError, URLError, subprocess.SubprocessError):
+        print("Pages publisher rejected the operation. Check workflow provenance, artifact validation, and documented configuration prerequisites.", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/ci/test-release-gates.sh
+++ b/scripts/ci/test-release-gates.sh
@@ -417,6 +417,7 @@ check("environment" not in pages_job, "Pages production promotion must not requi
 
 pages_if = str(pages_job.get("if", ""))
 for required_gate in (
+    "vars.MAPLE_PAGES_PRODUCTION_ENABLED != 'true'",
     "workflow_run.conclusion == 'success'",
     "workflow_run.event == 'release'",
     "workflow_run.path == '.github/workflows/release.yml'",

--- a/scripts/ci/test_pages_artifact.py
+++ b/scripts/ci/test_pages_artifact.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Adversarial archive tests; fixtures contain no credentials or production data."""
+
+import contextlib
+import gzip
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import stat
+import struct
+import sys
+import tarfile
+import tempfile
+import unittest
+from unittest.mock import patch
+import warnings
+import zipfile
+
+import pages_artifact as artifact
+
+
+SHA = "a" * 40
+RUN_ID = 12345
+ATTEMPT = 2
+CANARY = "UNTRUSTED_TEST_CANARY\n::error::injected"
+
+
+def tar_bytes(entries: list[tuple[str, bytes | None]], **options) -> bytes:
+    result = io.BytesIO()
+    with tarfile.open(fileobj=result, mode="w:gz", format=tarfile.GNU_FORMAT) as bundle:
+        for name, contents in entries:
+            member = tarfile.TarInfo(name)
+            member.mode = 0o7777
+            member.uid = member.gid = 65534
+            member.mtime = 1234567890
+            if contents is None:
+                member.type = tarfile.DIRTYPE
+            else:
+                member.size = len(contents)
+            for key, value in options.items():
+                setattr(member, key, value)
+            bundle.addfile(member, None if contents is None else io.BytesIO(contents))
+    return result.getvalue()
+
+
+class PagesArtifactTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.archive = self.root / artifact.ARCHIVE_NAME
+        self.destination = self.root / "dist"
+        self.preview = self.root / "preview.zip"
+        self.output_archive = self.root / "downloaded.tar.gz"
+        self.write_archive(
+            [
+                ("./assets/", None),
+                ("./assets/index-a123.js", b'console.log("fixture")'),
+                ("./assets/index-b123.css", b"body { color: #000; }"),
+                ("./favicon.svg", b"<svg></svg>"),
+                ("./index.html", b'<script src="/assets/index-a123.js"></script>'),
+            ]
+        )
+
+    def write_archive(self, entries: list[tuple[str, bytes | None]], **options) -> str:
+        self.archive.write_bytes(tar_bytes(entries, **options))
+        return self.digest()
+
+    def digest(self) -> str:
+        return hashlib.sha256(self.archive.read_bytes()).hexdigest()
+
+    def manifest(self) -> dict:
+        return artifact.pack_manifest(self.archive, "pr", SHA, RUN_ID, ATTEMPT)
+
+    def write_zip(self, entries=None, manifest=None, archive=None) -> None:
+        if entries is None:
+            entries = [
+                (artifact.ARCHIVE_NAME, self.archive.read_bytes() if archive is None else archive),
+                (artifact.MANIFEST_NAME, json.dumps(self.manifest() if manifest is None else manifest).encode()),
+            ]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            with zipfile.ZipFile(self.preview, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+                for name, data in entries:
+                    bundle.writestr(name, data)
+
+    def read_zip(self, **kwargs) -> dict:
+        return artifact.read_preview_zip(
+            self.preview,
+            kwargs.get("sha", SHA),
+            kwargs.get("run_id", RUN_ID),
+            kwargs.get("attempt", ATTEMPT),
+            self.output_archive,
+        )
+
+    def assert_rejected(self, operation) -> None:
+        with self.assertRaises(artifact.ArtifactError) as rejected:
+            operation()
+        self.assertNotIn(CANARY, str(rejected.exception))
+        self.assertNotIn("\n", str(rejected.exception))
+        self.assertFalse(self.destination.exists())
+        self.assertFalse(self.output_archive.exists())
+        self.assertEqual(list(self.root.glob(".pages-*")), [])
+
+    def test_manifest_fields_and_release_profile(self) -> None:
+        manifest = artifact.pack_manifest(self.archive, "release", SHA, RUN_ID, ATTEMPT)
+        self.assertEqual(set(manifest), artifact.MANIFEST_FIELDS)
+        self.assertEqual(manifest["profile"], "release")
+        self.assertEqual(manifest["archive_sha256"], self.digest())
+
+    def test_manifest_strict_types_and_unknown_fields(self) -> None:
+        mutations = [
+            ("schema_version", True), ("schema_version", 2),
+            ("profile", "production"), ("profile", CANARY), ("profile", []),
+            ("source_sha", SHA.upper()), ("source_sha", "a" * 39),
+            ("archive_sha256", "g" * 64), ("archive_sha256", CANARY),
+            ("run_id", True), ("run_id", "12345"), ("run_id", 0),
+            ("run_attempt", 0), ("run_attempt", 2.0), ("unknown", CANARY),
+        ]
+        for key, value in mutations:
+            with self.subTest(key=key, value=value):
+                manifest = self.manifest()
+                manifest[key] = value
+                self.assert_rejected(lambda: artifact.validate_manifest(manifest))
+        manifest = self.manifest()
+        del manifest["source_sha"]
+        self.assert_rejected(lambda: artifact.validate_manifest(manifest))
+
+    def test_manifest_creation_bounds_archive(self) -> None:
+        with patch.object(artifact, "MAX_ARCHIVE_BYTES", 4):
+            self.assert_rejected(self.manifest)
+
+    def test_valid_github_zip_and_real_shaped_static_archive(self) -> None:
+        self.write_zip()
+        manifest = self.read_zip()
+        self.assertEqual(self.output_archive.read_bytes(), self.archive.read_bytes())
+        hashes = artifact.extract_static(self.output_archive, self.destination, manifest["archive_sha256"])
+        self.assertEqual(set(hashes), {"index.html", "favicon.svg", "assets/index-a123.js", "assets/index-b123.css"})
+        for path, digest in hashes.items():
+            output = self.destination / path
+            self.assertEqual(hashlib.sha256(output.read_bytes()).hexdigest(), digest)
+            self.assertEqual(stat.S_IMODE(output.stat().st_mode), 0o644)
+        self.assertEqual(stat.S_IMODE(self.destination.stat().st_mode), 0o755)
+        self.assertEqual(stat.S_IMODE((self.destination / "assets").stat().st_mode), 0o755)
+
+    def test_zip_requires_matching_profile_sha_run_and_attempt(self) -> None:
+        for key, value in [("profile", "release"), ("source_sha", "b" * 40), ("run_id", 12346), ("run_attempt", 1)]:
+            with self.subTest(field=key):
+                manifest = self.manifest()
+                manifest[key] = value
+                self.write_zip(manifest=manifest)
+                self.assert_rejected(self.read_zip)
+
+    def test_zip_rejects_invalid_expected_identity(self) -> None:
+        self.write_zip()
+        for arguments in ({"sha": CANARY}, {"run_id": True}, {"attempt": 0}):
+            with self.subTest(arguments=arguments):
+                self.assert_rejected(lambda: self.read_zip(**arguments))
+
+    def test_zip_digest_is_checked_before_publishing(self) -> None:
+        self.write_zip(archive=b"different bytes")
+        self.assert_rejected(self.read_zip)
+
+    def test_zip_rejects_traversal_extra_missing_and_duplicate_entries(self) -> None:
+        payload = json.dumps(self.manifest()).encode()
+        for names in (
+            ["../maple-web-dist.tar.gz", artifact.MANIFEST_NAME],
+            ["/maple-web-dist.tar.gz", artifact.MANIFEST_NAME],
+            ["sub/maple-web-dist.tar.gz", artifact.MANIFEST_NAME],
+            [artifact.ARCHIVE_NAME, artifact.ARCHIVE_NAME],
+            [artifact.ARCHIVE_NAME],
+            [artifact.ARCHIVE_NAME, artifact.MANIFEST_NAME, "extra"],
+            [artifact.ARCHIVE_NAME, "bad\n::error::injected"],
+        ):
+            with self.subTest(names=names):
+                self.write_zip([(name, payload) for name in names])
+                self.assert_rejected(self.read_zip)
+
+    def test_zip_rejects_symlinks_directories_and_special_files(self) -> None:
+        for unix_type in (stat.S_IFLNK, stat.S_IFDIR, stat.S_IFIFO, stat.S_IFCHR):
+            with self.subTest(unix_type=unix_type):
+                member = zipfile.ZipInfo(artifact.ARCHIVE_NAME)
+                member.create_system = 3
+                member.external_attr = (unix_type | 0o755) << 16
+                self.write_zip([(member, b"ignored"), (artifact.MANIFEST_NAME, json.dumps(self.manifest()).encode())])
+                self.assert_rejected(self.read_zip)
+
+    def test_zip_rejects_dos_directory_attribute(self) -> None:
+        member = zipfile.ZipInfo(artifact.ARCHIVE_NAME)
+        member.external_attr = 0x10
+        self.write_zip([(member, b"ignored"), (artifact.MANIFEST_NAME, json.dumps(self.manifest()).encode())])
+        self.assert_rejected(self.read_zip)
+
+    def test_zip_rejects_duplicate_manifest_fields_and_invalid_json(self) -> None:
+        for data in (b'{"profile":"pr","profile":"release"}', b"\xff", b"[", b"null"):
+            with self.subTest(data=data):
+                self.write_zip([(artifact.ARCHIVE_NAME, self.archive.read_bytes()), (artifact.MANIFEST_NAME, data)])
+                self.assert_rejected(self.read_zip)
+
+    def test_zip_manifest_and_archive_size_limits(self) -> None:
+        self.write_zip()
+        for limit in ("MAX_MANIFEST_BYTES", "MAX_ARCHIVE_BYTES"):
+            with self.subTest(limit=limit), patch.object(artifact, limit, 4):
+                self.assert_rejected(self.read_zip)
+
+    def test_zip_entry_count_checked_before_parser_allocates_entries(self) -> None:
+        self.write_zip()
+        contents = bytearray(self.preview.read_bytes())
+        end = contents.rfind(b"PK\x05\x06")
+        struct.pack_into("<HH", contents, end + 8, 65000, 65000)
+        self.preview.write_bytes(contents)
+        with patch.object(artifact.zipfile, "ZipFile", side_effect=AssertionError("Parser must not run")):
+            self.assert_rejected(self.read_zip)
+
+    def test_zip_never_overwrites_an_existing_output(self) -> None:
+        self.write_zip()
+        self.output_archive.write_bytes(b"keep")
+        with self.assertRaises(artifact.ArtifactError):
+            self.read_zip()
+        self.assertEqual(self.output_archive.read_bytes(), b"keep")
+
+    def test_tar_path_traversal_and_log_injection(self) -> None:
+        for name in (
+            "../outside", "/outside", "./../outside", "a/../../outside", "a//b", "a/./b",
+            "a\\b", "C:/outside", "a\nb", "a\rb", "a\x1bb", "a\u202eb", CANARY,
+            "././index.html", ".env", "a/.git/config", "a/.well-known/file",
+            "assets/\u0065\u0301.txt",
+        ):
+            with self.subTest(name=name):
+                digest = self.write_archive([("index.html", b"safe"), (name, b"bad")])
+                self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, digest))
+        self.assertFalse((self.root / "outside").exists())
+
+    def test_tar_rejects_runtime_and_configuration_files_at_any_depth(self) -> None:
+        for component in artifact.RESERVED_COMPONENTS:
+            for name in (component, "assets/" + component.upper(), "a/" + component + "/payload"):
+                with self.subTest(name=name):
+                    digest = self.write_archive([("index.html", b"safe"), (name, b"bad")])
+                    self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, digest))
+
+    def test_tar_preserves_public_root_mobile_association_documents(self) -> None:
+        documents = {
+            ".well-known/apple-app-site-association": b'{"applinks":{"details":[]}}',
+            ".well-known/assetlinks.json": b"[]",
+        }
+        digest = self.write_archive(
+            [("index.html", b"safe"), ("./.well-known/", None)]
+            + [("./" + name, contents) for name, contents in documents.items()]
+        )
+        hashes = artifact.extract_static(self.archive, self.destination, digest)
+        for name, contents in documents.items():
+            self.assertEqual((self.destination / name).read_bytes(), contents)
+            self.assertEqual(hashes[name], hashlib.sha256(contents).hexdigest())
+
+    def test_well_known_exception_cannot_expose_hidden_or_runtime_files(self) -> None:
+        forbidden = [
+            ".well-known", ".WELL-KNOWN/assetlinks.json", "a/.well-known/assetlinks.json",
+            ".well-known/.env", ".well-known/.git/config",
+            ".well-known/a/.well-known/assetlinks.json",
+        ] + [".well-known/" + name for name in artifact.RESERVED_COMPONENTS]
+        for name in forbidden:
+            with self.subTest(name=name):
+                digest = self.write_archive([("index.html", b"safe"), (name, b"bad")])
+                self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, digest))
+
+    def test_tar_rejects_links_devices_fifo_and_sparse(self) -> None:
+        for member_type in (tarfile.SYMTYPE, tarfile.LNKTYPE, tarfile.CHRTYPE, tarfile.BLKTYPE, tarfile.FIFOTYPE, tarfile.GNUTYPE_SPARSE):
+            with self.subTest(member_type=member_type):
+                digest = self.write_archive([("index.html", b"")], type=member_type, linkname="/outside")
+                self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, digest))
+
+    def test_tar_rejects_duplicate_and_case_conflicting_paths(self) -> None:
+        for first, second in (
+            ("index.html", "./index.html"),
+            ("assets/a.js", "assets/a.js"),
+            ("assets/a.js", "assets/A.js"),
+            ("ASSETS/a.js", "assets/b.js"),
+            ("assets", "assets/a.js"),
+            ("assets/a.js", "assets"),
+        ):
+            with self.subTest(paths=(first, second)):
+                digest = self.write_archive([(first, b"safe"), (second, b"bad")])
+                self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, digest))
+
+    def test_tar_rejects_duplicate_directories(self) -> None:
+        digest = self.write_archive([("assets/", None), ("./assets/", None), ("index.html", b"safe")])
+        self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, digest))
+
+    def test_tar_requires_root_index_html(self) -> None:
+        digest = self.write_archive([("assets/index.html", b"safe")])
+        self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, digest))
+
+    def test_tar_bounds_compressed_input_and_each_file(self) -> None:
+        for limit in ("MAX_ARCHIVE_BYTES", "MAX_FILE_BYTES"):
+            with self.subTest(limit=limit), patch.object(artifact, limit, 4):
+                self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, self.digest()))
+
+    def test_tar_bounds_entry_count(self) -> None:
+        with patch.object(artifact, "MAX_ENTRIES", 2):
+            self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, self.digest()))
+
+    def test_tar_bounds_decompression_and_metadata(self) -> None:
+        digest = self.write_archive([("index.html", b"a" * 8000)])
+        with patch.object(artifact, "MAX_EXPANDED_BYTES", 4096):
+            self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, digest))
+        digest = self.write_archive([("index.html", b"safe"), ("a" * 200, b"safe")])
+        with patch.object(artifact, "MAX_EXPANDED_BYTES", 1536):
+            self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, digest))
+
+    def test_tar_bounds_compressed_data_after_tar_end(self) -> None:
+        self.archive.write_bytes(self.archive.read_bytes() + gzip.compress(b"a" * 100_000))
+        with patch.object(artifact, "MAX_EXPANDED_BYTES", 20_000):
+            self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, self.digest()))
+
+    def test_tar_invalid_gzip_and_wrong_digest(self) -> None:
+        self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, "0" * 64))
+        self.archive.write_bytes(b"not gzip " + CANARY.encode())
+        self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, self.digest()))
+
+    def test_tar_truncated_gzip_is_rejected(self) -> None:
+        self.archive.write_bytes(self.archive.read_bytes()[:-4])
+        self.assert_rejected(lambda: artifact.extract_static(self.archive, self.destination, self.digest()))
+
+    def test_tar_rejects_symlink_input_and_preserves_destination(self) -> None:
+        link = self.root / "linked.tar.gz"
+        link.symlink_to(self.archive)
+        self.assert_rejected(lambda: artifact.extract_static(link, self.destination, self.digest()))
+        self.destination.mkdir()
+        (self.destination / "existing").write_bytes(b"keep")
+        with self.assertRaises(artifact.ArtifactError):
+            artifact.extract_static(self.archive, self.destination, self.digest())
+        self.assertEqual((self.destination / "existing").read_bytes(), b"keep")
+
+    def test_tar_accepts_empty_existing_destination(self) -> None:
+        self.destination.mkdir()
+        artifact.extract_static(self.archive, self.destination, self.digest())
+        self.assertTrue((self.destination / "index.html").is_file())
+
+    def test_tar_rejects_symlink_destination(self) -> None:
+        outside = self.root / "outside"
+        outside.mkdir()
+        self.destination.symlink_to(outside, target_is_directory=True)
+        with self.assertRaises(artifact.ArtifactError):
+            artifact.extract_static(self.archive, self.destination, self.digest())
+        self.assertEqual(list(outside.iterdir()), [])
+
+    def test_nested_archive_is_inert_static_bytes(self) -> None:
+        nested = tar_bytes([("../outside", b"bad")])
+        digest = self.write_archive([("index.html", b"safe"), ("assets/example.tar.gz", nested)])
+        hashes = artifact.extract_static(self.archive, self.destination, digest)
+        self.assertEqual(hashes["assets/example.tar.gz"], hashlib.sha256(nested).hexdigest())
+        self.assertFalse((self.root / "outside").exists())
+
+    def test_manifest_cli_and_safe_errors(self) -> None:
+        output = self.root / "manifest.json"
+        arguments = ["pages_artifact.py", "manifest", "--archive", str(self.archive), "--profile", "pr", "--sha", SHA, "--run-id", str(RUN_ID), "--run-attempt", str(ATTEMPT), "--output", str(output)]
+        with patch.object(sys, "argv", arguments):
+            self.assertEqual(artifact.main(), 0)
+        self.assertEqual(json.loads(output.read_text()), self.manifest())
+        for flag in ("--sha", "--profile", "--run-id", "--archive"):
+            with self.subTest(flag=flag):
+                invalid = arguments.copy()
+                invalid[invalid.index(flag) + 1] = CANARY
+                captured = io.StringIO()
+                with patch.object(sys, "argv", invalid), contextlib.redirect_stderr(captured), contextlib.redirect_stdout(captured):
+                    try:
+                        result = artifact.main()
+                    except SystemExit as error:
+                        result = error.code
+                self.assertNotEqual(result, 0)
+                self.assertNotIn("UNTRUSTED_TEST_CANARY", captured.getvalue())
+                self.assertNotIn("::error::injected", captured.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_pages_deploy.py
+++ b/scripts/ci/test_pages_deploy.py
@@ -1,0 +1,326 @@
+"""Attack and regression cases for the trusted publisher, without live writes."""
+
+import copy
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import pages_deploy as pages
+
+SHA = "a" * 40
+OLD_SHA = "b" * 40
+OTHER_SHA = "c" * 40
+REPO_ID = 923138240
+
+
+class MemoryAPI:
+    def __init__(self, values):
+        self.values = values
+
+    def json(self, path, method="GET", data=None):
+        if method != "GET":
+            raise AssertionError("Selection must never mutate GitHub")
+        return copy.deepcopy(self.values[path])
+
+
+class ProvenanceTests(unittest.TestCase):
+    def setUp(self):
+        self.repo = "OpenSecretCloud/Maple"
+        self.root = "/repos/" + self.repo
+        self.run = {"id": 100, "workflow_id": 10, "path": ".github/workflows/pages-preview-build.yml",
+                    "event": "pull_request", "status": "completed", "conclusion": "success",
+                    "run_attempt": 2, "head_sha": SHA, "head_branch": "feature", "pull_requests": [],
+                    "repository": {"id": REPO_ID}, "head_repository": {"id": REPO_ID}}
+        self.pr = {"number": 877, "state": "open", "base": {"ref": "master", "repo": {"id": REPO_ID}},
+                   "head": {"sha": SHA, "ref": "feature", "repo": {"id": REPO_ID}}}
+        self.artifact = {"id": 300, "name": "maple-pages-preview-100-2", "expired": False,
+                         "digest": "sha256:" + "d" * 64, "size_in_bytes": 1000}
+        self.values = {self.root: {"id": REPO_ID, "default_branch": "master"},
+                       self.root + "/actions/runs/100": self.run,
+                       self.root + "/actions/workflows/pages-preview-build.yml": {"id": 10},
+                       self.root + f"/commits/{SHA}/pulls?per_page=100": [{"number": 877}],
+                       self.root + "/pulls/877": self.pr,
+                       self.root + "/git/ref/heads/master": {"object": {"sha": SHA}},
+                       self.root + "/actions/runs/100/artifacts?per_page=100": {"total_count": 1, "artifacts": [self.artifact]}}
+        self.event = {"workflow_run": copy.deepcopy(self.run)}
+        self.gh = pages.GitHub(MemoryAPI(self.values), self.repo, REPO_ID)
+
+    def select(self):
+        return pages.select_plan(self.gh, self.event, "preview")
+
+    def test_internal_pr_with_empty_event_pr_list(self):
+        plan = self.select()
+        self.assertEqual((plan["branch"], plan["profile"], plan["sha"]), ("pr-877", "pr", SHA))
+        self.assertEqual(plan["artifact_id"], 300)
+
+    def test_owner_rename_does_not_change_repository_identity(self):
+        new_repo = "MaplePrivacyLabs/Maple"
+        moved = {key.replace(self.root, "/repos/" + new_repo): value for key, value in self.values.items()}
+        gh = pages.GitHub(MemoryAPI(moved), new_repo, REPO_ID)
+        self.assertEqual(pages.select_plan(gh, self.event, "preview")["sha"], SHA)
+
+    def test_fork_run_never_eligible_even_when_pr_commit_is_shared(self):
+        self.run["head_repository"]["id"] = 99
+        with self.assertRaises(pages.Rejected):
+            self.select()
+
+    def test_fork_pr_rejected_even_if_workflow_metadata_claims_internal(self):
+        self.pr["head"]["repo"]["id"] = 99
+        with self.assertRaises(pages.Superseded):
+            self.select()
+
+    def test_closed_changed_head_and_wrong_base_prs(self):
+        for mutate in (lambda: self.pr.update(state="closed"),
+                       lambda: self.pr["head"].update(sha=OTHER_SHA),
+                       lambda: self.pr["base"].update(ref="not-master"),
+                       lambda: self.pr["base"]["repo"].update(id=99),
+                       lambda: self.pr["head"].update(repo=None),
+                       lambda: self.pr["head"].update(ref="other-branch")):
+            original = copy.deepcopy(self.pr)
+            mutate()
+            with self.assertRaises(pages.Superseded):
+                self.select()
+            self.pr.clear()
+            self.pr.update(original)
+
+    def test_run_attempt_race(self):
+        self.run["run_attempt"] = 3
+        with self.assertRaises(pages.Superseded):
+            self.select()
+
+    def test_wrong_workflow_identity_path_or_event(self):
+        for key, value in (("workflow_id", 123), ("path", ".github/workflows/evil.yml"),
+                           ("event", "pull_request_target"), ("conclusion", "failure"), ("status", "in_progress")):
+            old = self.run[key]
+            self.run[key] = value
+            with self.assertRaises(pages.Rejected):
+                self.select()
+            self.run[key] = old
+
+    def test_trigger_sha_must_agree_with_api(self):
+        self.event["workflow_run"]["head_sha"] = OTHER_SHA
+        with self.assertRaises(pages.Rejected):
+            self.select()
+
+    def test_previous_attempt_artifact_not_selected(self):
+        self.artifact["name"] = "maple-pages-preview-100-1"
+        with self.assertRaises(pages.Rejected):
+            self.select()
+
+    def test_duplicate_expired_and_unsigned_artifacts_rejected(self):
+        artifact_list = self.values[self.root + "/actions/runs/100/artifacts?per_page=100"]["artifacts"]
+        artifact_list.append(copy.deepcopy(self.artifact))
+        with self.assertRaises(pages.Rejected):
+            self.select()
+        artifact_list.pop()
+        self.artifact["expired"] = True
+        with self.assertRaises(pages.Rejected):
+            self.select()
+        self.artifact["expired"] = False
+        self.artifact["digest"] = None
+        with self.assertRaises(pages.Rejected):
+            self.select()
+
+    def test_master_preview_is_dev_and_must_be_current(self):
+        self.run.update(event="push", head_branch="master")
+        self.event = {"workflow_run": copy.deepcopy(self.run)}
+        plan = self.select()
+        self.assertEqual((plan["profile"], plan["branch"], plan["pr_number"]), ("pr", "master", None))
+        self.values[self.root + "/git/ref/heads/master"]["object"]["sha"] = OTHER_SHA
+        with self.assertRaises(pages.Superseded):
+            self.select()
+
+    def setup_release(self):
+        self.run.update(event="release", head_branch="v3.3.10", path=".github/workflows/release.yml", workflow_id=11)
+        self.event = {"workflow_run": copy.deepcopy(self.run)}
+        self.release = {"id": 900, "tag_name": "v3.3.10", "draft": False, "prerelease": False,
+                        "assets": [{"id": 1, "name": "maple-web-dist.tar.gz", "state": "uploaded", "size": 8000,
+                                    "digest": "sha256:" + "d" * 64},
+                                   {"id": 2, "name": "web-final.sha256", "state": "uploaded", "size": 130,
+                                    "digest": "sha256:" + "e" * 64}]}
+        self.values.update({self.root + "/releases/latest": self.release,
+                            self.root + "/commits/v3.3.10": {"sha": SHA},
+                            self.root + "/actions/workflows/release.yml": {"id": 11},
+                            self.root + f"/compare/{SHA}...master": {"status": "ahead"},
+                            self.root + "/git/ref/heads/pages-production": {"object": {"sha": OLD_SHA}},
+                            self.root + f"/compare/{OLD_SHA}...{SHA}": {"status": "ahead"},
+                            self.root + f"/actions/workflows/release.yml/runs?event=release&head_sha={SHA}&per_page=100": {"workflow_runs": [self.run]}})
+
+    def production(self):
+        return pages.select_plan(self.gh, self.event, "production")
+
+    def test_release_selects_exact_production_asset(self):
+        self.setup_release()
+        plan = self.production()
+        self.assertEqual((plan["branch"], plan["profile"], plan["sha"]), ("pages-production", "release", SHA))
+        self.assertEqual(plan["archive"]["id"], 1)
+
+    def test_current_release_can_be_redeployed_without_a_new_release(self):
+        self.setup_release()
+        self.values[self.root + "/git/ref/heads/pages-production"]["object"]["sha"] = SHA
+        self.event = {}
+        self.assertEqual(self.production()["previous_sha"], SHA)
+
+    def test_draft_prerelease_and_malformed_tag_rejected(self):
+        self.setup_release()
+        for field, value in (("draft", True), ("prerelease", True), ("tag_name", "v3.3.10\n::error::injection")):
+            old = self.release[field]
+            self.release[field] = value
+            with self.assertRaises(pages.Rejected):
+                self.production()
+            self.release[field] = old
+
+    def test_release_superseded_by_new_tag(self):
+        self.setup_release()
+        self.event["workflow_run"]["head_branch"] = "v3.3.9"
+        with self.assertRaises(pages.Superseded):
+            self.production()
+
+    def test_release_run_must_match_tag_sha(self):
+        self.setup_release()
+        self.run["head_sha"] = OTHER_SHA
+        with self.assertRaises(pages.Rejected):
+            self.production()
+
+    def test_release_must_be_on_master_and_forward(self):
+        self.setup_release()
+        for path in (f"/compare/{SHA}...master", f"/compare/{OLD_SHA}...{SHA}"):
+            self.values[self.root + path]["status"] = "diverged"
+            with self.assertRaises(pages.Rejected):
+                self.production()
+            self.values[self.root + path]["status"] = "ahead"
+
+    def test_manual_retry_does_not_accept_failed_release(self):
+        self.setup_release()
+        self.event = {}
+        self.run["conclusion"] = "failure"
+        with self.assertRaises(pages.Rejected):
+            self.production()
+
+    def test_release_digest_and_asset_uniqueness_required(self):
+        self.setup_release()
+        self.release["assets"].append(copy.deepcopy(self.release["assets"][0]))
+        with self.assertRaises(pages.Rejected):
+            self.production()
+        self.release["assets"].pop()
+        self.release["assets"][0]["digest"] = None
+        with self.assertRaises(pages.Rejected):
+            self.production()
+
+
+class ProcessAndTransportTests(unittest.TestCase):
+    def test_wrangler_rejects_ancestor_configuration(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            parent = Path(tmp)
+            cwd = parent / "nested" / "runner"
+            cwd.mkdir(parents=True)
+            # Isolate test from the host's own ancestors; only our fixture matters.
+            for name in ("wrangler.toml", "wrangler.json", "wrangler.jsonc", "package.json", ".env", ".dev.vars"):
+                config = parent / name
+                config.write_text("fixture")
+                with self.assertRaises(pages.Rejected):
+                    pages.require_clean_wrangler_ancestors(cwd)
+                config.unlink()
+            (parent / ".wrangler").mkdir()
+            with self.assertRaises(pages.Rejected):
+                pages.require_clean_wrangler_ancestors(cwd)
+
+    def test_child_environment_drops_every_other_credential_and_runtime_override(self):
+        injected = {"PATH": "/trusted/bin", "GH_TOKEN": "fake-gh-secret", "GITHUB_TOKEN": "other-fake",
+                    "NODE_OPTIONS": "--require=/evil", "BUN_OPTIONS": "--preload=/evil", "PYTHONPATH": "/evil",
+                    "HOME": "/attacker", "HTTPS_PROXY": "https://attacker.invalid", "BWS_ACCESS_TOKEN": "fake-bws",
+                    "GITHUB_ENV": "/commands", "GITHUB_OUTPUT": "/commands", "CLOUDFLARE_API_BASE_URL": "https://attacker.invalid"}
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(os.environ, injected, clear=True):
+            result = pages.wrangler_environment("a" * 32, "fake-cf-canary", Path(tmp))
+            self.assertEqual(result["CLOUDFLARE_API_TOKEN"], "fake-cf-canary")
+            for key in injected.keys() - {"PATH", "HOME"}:
+                self.assertNotIn(key, result)
+            self.assertNotEqual(result["HOME"], "/attacker")
+            self.assertNotIn("fake-gh-secret", json.dumps(result))
+
+    def test_cf_project_identity_and_automatic_build_gate(self):
+        project = {"success": True, "result": {"name": "maple", "subdomain": pages.SUBDOMAIN,
+                   "production_branch": "pages-production", "source": {"config": {"production_deployments_enabled": False}}}}
+        api = MemoryAPI({"/accounts/abc/pages/projects/maple": project})
+        pages.cloudflare_project(api, "abc", "production")
+        project["result"]["source"]["config"]["production_deployments_enabled"] = True
+        with self.assertRaises(pages.Rejected):
+            pages.cloudflare_project(api, "abc", "production")
+        # Preview pilots can coexist until the operator turns off native previews.
+        pages.cloudflare_project(api, "abc", "preview")
+        project["result"]["subdomain"] = "wrong.pages.dev"
+        with self.assertRaises(pages.Rejected):
+            pages.cloudflare_project(api, "abc", "preview")
+
+    def test_artifact_redirect_never_receives_github_authorization(self):
+        requests = []
+
+        class Opener:
+            def open(self, request, timeout):
+                requests.append(request)
+                if len(requests) == 1:
+                    raise HTTPError(request.full_url, 302, "redirect", {"Location": "https://storage.example/artifact?signature=fake"}, None)
+                return io.BytesIO(b"archive")
+
+        api = pages.API("https://api.github.com", "fake-gh-canary")
+        api.opener = Opener()
+        with tempfile.TemporaryDirectory() as tmp:
+            api.download("/repos/owner/repo/actions/artifacts/12/zip", Path(tmp) / "a.zip",
+                         expected_size=7, expected_digest=hashlib.sha256(b"archive").hexdigest())
+        self.assertEqual(requests[0].get_header("Authorization"), "Bearer fake-gh-canary")
+        self.assertIsNone(requests[1].get_header("Authorization"))
+
+    def test_preview_waits_for_deploy_success_not_an_earlier_stage(self):
+        result = {"deployment_id": "a" * 36, "url": "https://12345678.maple-ca8.pages.dev"}
+        plan = {"target": "preview", "sha": SHA, "branch": "pr-12"}
+        deployment = {"environment": "preview", "project_name": "maple", "url": result["url"],
+                      "deployment_trigger": {"metadata": {"commit_hash": SHA, "branch": "pr-12"}}}
+        api = pages.API("https://api.cloudflare.com/client/v4", "fake-cf-canary")
+        stages = [{"name": "build", "status": "success"}, {"name": "deploy", "status": "active"},
+                  {"name": "deploy", "status": "success"}]
+        replies = [{"success": True, "result": {**deployment, "latest_stage": stage}} for stage in stages]
+        with patch.object(api, "json", side_effect=replies) as read, patch.object(pages.time, "sleep") as sleep:
+            pages.verify_deployment(api, "a" * 32, plan, result)
+        self.assertEqual(read.call_count, 3)
+        self.assertEqual(sleep.call_count, 2)
+
+    def test_non_https_redirect_rejected_without_second_request(self):
+        class Opener:
+            def open(self, request, timeout):
+                raise HTTPError(request.full_url, 302, "redirect", {"Location": "http://attacker.invalid/artifact"}, None)
+
+        api = pages.API("https://api.github.com", "fake-gh-canary")
+        api.opener = Opener()
+        with tempfile.TemporaryDirectory() as tmp, self.assertRaises(pages.Rejected):
+            api.download("/artifact", Path(tmp) / "a.zip")
+
+    def test_download_bounds_size_and_digest(self):
+        class Opener:
+            def open(self, request, timeout):
+                return io.BytesIO(b"archive")
+
+        for kwargs in ({"limit": 6}, {"expected_size": 8}, {"expected_digest": "0" * 64}):
+            api = pages.API("https://api.github.com", "fake-gh-canary")
+            api.opener = Opener()
+            with tempfile.TemporaryDirectory() as tmp, self.assertRaises(pages.Rejected):
+                api.download("/artifact", Path(tmp) / "a.zip", **kwargs)
+
+    def test_identifiers_cannot_inject_api_paths_or_output(self):
+        for value in (True, -1, "12\n::error::injected", "1/../../secrets"):
+            with self.assertRaises(pages.Rejected):
+                pages.number(value)
+        for value in (SHA + "\n::error::injected", "../../master", "$(env)"):
+            with self.assertRaises(pages.Rejected):
+                pages.sha(value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_pages_deploy.py
+++ b/scripts/ci/test_pages_deploy.py
@@ -274,9 +274,17 @@ class ProcessAndTransportTests(unittest.TestCase):
         api.opener = Opener()
         with tempfile.TemporaryDirectory() as tmp:
             api.download("/repos/owner/repo/actions/artifacts/12/zip", Path(tmp) / "a.zip",
-                         expected_size=7, expected_digest=hashlib.sha256(b"archive").hexdigest())
+                         expected_size=7, expected_digest=hashlib.sha256(b"archive").hexdigest(),
+                         accept="application/vnd.github+json")
         self.assertEqual(requests[0].get_header("Authorization"), "Bearer fake-gh-canary")
+        self.assertEqual(requests[0].get_header("Accept"), "application/vnd.github+json")
         self.assertIsNone(requests[1].get_header("Authorization"))
+
+    def test_release_asset_requests_binary_representation(self):
+        api = pages.API("https://api.github.com", "fake-gh-canary")
+        with tempfile.TemporaryDirectory() as tmp, patch.object(api, "request", return_value=io.BytesIO(b"archive")) as request:
+            api.download("/repos/owner/repo/releases/assets/12", Path(tmp) / "archive")
+        request.assert_called_once_with("/repos/owner/repo/releases/assets/12", accept="application/octet-stream")
 
     def test_preview_waits_for_deploy_success_not_an_earlier_stage(self):
         result = {"deployment_id": "a" * 36, "url": "https://12345678.maple-ca8.pages.dev"}

--- a/scripts/ci/test_pages_workflows.py
+++ b/scripts/ci/test_pages_workflows.py
@@ -1,0 +1,264 @@
+"""Regression checks for the GitHub Actions credential and source boundaries."""
+
+import copy
+import functools
+import json
+from pathlib import Path
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+@functools.cache
+def workflow(name):
+    result = subprocess.run(
+        ["yq", "-o=json", ".", str(WORKFLOWS / name)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def normalized(value):
+    return " ".join(value.split())
+
+
+def strings(value):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for child in value.values():
+            yield from strings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from strings(child)
+
+
+class PagesWorkflowTests(unittest.TestCase):
+    def assert_no_secrets(self, value):
+        for text in strings(value):
+            self.assertNotRegex(text, r"\bsecrets\b")
+
+    def test_build_is_unprivileged_and_skips_forks(self):
+        build = workflow("pages-preview-build.yml")
+        self.assertEqual(build["name"], "Pages preview build")
+        self.assertEqual(set(build["on"]), {"push", "pull_request"})
+        self.assertEqual(build["permissions"], {"contents": "read"})
+        self.assert_no_secrets(build)
+        self.assertEqual(set(build["jobs"]), {"build-preview"})
+        job = build["jobs"]["build-preview"]
+        self.assertNotIn("permissions", job)
+        self.assertNotIn("environment", job)
+        self.assertEqual(
+            normalized(job["if"]),
+            "github.event_name == 'push' || "
+            "(github.event_name == 'pull_request' && "
+            "github.event.pull_request.head.repo.full_name == github.repository)",
+        )
+        self.assertEqual(
+            job["env"]["SOURCE_SHA"],
+            "${{ github.event_name == 'pull_request' && "
+            "github.event.pull_request.head.sha || github.sha }}",
+        )
+        checkouts = [
+            step for step in job["steps"]
+            if step.get("uses", "").startswith("actions/checkout@")
+        ]
+        self.assertEqual(len(checkouts), 2)
+        self.assertEqual(
+            checkouts[0]["with"],
+            {"ref": "${{ env.SOURCE_SHA }}", "persist-credentials": False},
+        )
+        self.assertEqual(
+            checkouts[1]["with"],
+            {"ref": "${{ github.sha }}", "path": ".pages-tools", "persist-credentials": False},
+        )
+
+    def test_master_preview_uses_the_same_development_profile_as_prs(self):
+        preview = workflow("pages-preview-build.yml")
+        old_build = workflow("web-build.yml")
+        for event in ("push", "pull_request"):
+            self.assertEqual(preview["on"][event]["branches"], ["master"])
+            self.assertTrue(
+                set(old_build["on"][event]["paths"])
+                <= set(preview["on"][event]["paths"])
+            )
+        build_steps = [
+            step for step in preview["jobs"]["build-preview"]["steps"]
+            if "./scripts/ci/web.sh" in step.get("run", "")
+        ]
+        self.assertEqual(len(build_steps), 1)
+        self.assertEqual(build_steps[0]["env"], {"MAPLE_WEB_ENVIRONMENT": "pr"})
+        self.assertNotIn("if", build_steps[0])
+
+    def test_preview_artifact_is_bound_to_one_run_and_attempt(self):
+        steps = workflow("pages-preview-build.yml")["jobs"]["build-preview"]["steps"]
+        uploads = [
+            step for step in steps
+            if step.get("uses", "").startswith("actions/upload-artifact@")
+        ]
+        self.assertEqual(len(uploads), 1)
+        upload = uploads[0]["with"]
+        self.assertEqual(
+            upload["name"],
+            "maple-pages-preview-${{ github.run_id }}-${{ github.run_attempt }}",
+        )
+        self.assertEqual(
+            upload["path"].splitlines(),
+            [
+                "frontend/src-tauri/target/reproducibility/maple-web-dist.tar.gz",
+                "frontend/src-tauri/target/reproducibility/pages-artifact.json",
+            ],
+        )
+        self.assertEqual(upload["if-no-files-found"], "error")
+        descriptions = [
+            step["run"] for step in steps
+            if "scripts/ci/pages_artifact.py" in step.get("run", "")
+        ]
+        self.assertEqual(len(descriptions), 1)
+        self.assertIn('"$GITHUB_WORKSPACE/.pages-tools#pages"', descriptions[0])
+        self.assertIn(
+            '-c python3 -I "$GITHUB_WORKSPACE/.pages-tools/scripts/ci/pages_artifact.py" manifest',
+            descriptions[0],
+        )
+        for argument in (
+            "--profile pr", '--sha "$SOURCE_SHA"',
+            '--run-id "$GITHUB_RUN_ID"', '--run-attempt "$GITHUB_RUN_ATTEMPT"',
+        ):
+            self.assertIn(argument, descriptions[0])
+
+    def test_publisher_uses_only_trusted_checkout_and_dependencies(self):
+        publish = workflow("pages-publish.yml")
+        self.assertEqual(set(publish["on"]), {"workflow_run", "workflow_dispatch"})
+        self.assertEqual(
+            publish["on"]["workflow_run"],
+            {"workflows": ["Pages preview build", "Release"], "types": ["completed"]},
+        )
+        self.assertEqual(publish["permissions"], {"contents": "read"})
+        self.assertEqual(set(publish["jobs"]), {"preview", "production"})
+        for job in publish["jobs"].values():
+            with self.subTest(job=job["name"]):
+                checkouts = [
+                    step for step in job["steps"]
+                    if step.get("uses", "").startswith("actions/checkout@")
+                ]
+                self.assertEqual(len(checkouts), 1)
+                self.assertEqual(
+                    checkouts[0]["with"],
+                    {"ref": "${{ github.sha }}", "persist-credentials": False},
+                )
+                actions = [step["uses"].split("@")[0] for step in job["steps"] if "uses" in step]
+                self.assertEqual(actions, ["actions/checkout", "DeterminateSystems/nix-installer-action"])
+                installs = [step for step in job["steps"] if "bun install" in step.get("run", "")]
+                self.assertEqual(len(installs), 1)
+                self.assertEqual(installs[0]["working-directory"], "updates")
+                self.assertEqual(
+                    installs[0]["run"],
+                    "nix develop --no-update-lock-file ..#pages -c bun install --frozen-lockfile --ignore-scripts",
+                )
+                for step in job["steps"]:
+                    self.assertNotIn("${{", step.get("run", ""))
+                    self.assertNotIn(".#ci", step.get("run", ""))
+
+    def test_cf_credentials_exist_only_in_final_deploy_step(self):
+        publish = workflow("pages-publish.yml")
+        self.assertNotIn("env", publish)
+        for target, job in publish["jobs"].items():
+            with self.subTest(target=target):
+                self.assertNotIn("env", job)
+                self.assertEqual(job["environment"]["name"], f"pages-{target}")
+                steps = job["steps"]
+                deploy = steps[-1]
+                self.assertEqual(
+                    deploy["env"],
+                    {
+                        "GH_TOKEN": "${{ github.token }}",
+                        "CLOUDFLARE_ACCOUNT_ID": "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}",
+                        "CLOUDFLARE_API_TOKEN": "${{ secrets.CLOUDFLARE_API_TOKEN }}",
+                    },
+                )
+                self.assertEqual(
+                    deploy["run"],
+                    "nix develop --no-update-lock-file .#pages -c python3 -I scripts/ci/pages_deploy.py "
+                    'deploy --state "$RUNNER_TEMP/maple-pages"',
+                )
+                self.assertEqual(
+                    steps[-2]["run"],
+                    "nix develop --no-update-lock-file .#pages -c python3 -I scripts/ci/pages_deploy.py "
+                    f'prepare --target {target} --state "$RUNNER_TEMP/maple-pages"',
+                )
+                self.assertEqual(steps[-2]["env"], {"GH_TOKEN": "${{ github.token }}"})
+                before_secrets = copy.deepcopy(job)
+                before_secrets["steps"] = steps[:-1]
+                self.assert_no_secrets(before_secrets)
+
+    def test_publisher_permissions_do_not_expand_build_authority(self):
+        jobs = workflow("pages-publish.yml")["jobs"]
+        self.assertEqual(
+            jobs["preview"]["permissions"],
+            {"contents": "read", "actions": "read", "pull-requests": "write", "deployments": "write"},
+        )
+        self.assertEqual(
+            jobs["production"]["permissions"],
+            {"contents": "write", "actions": "read", "deployments": "write"},
+        )
+
+    def test_rollout_and_event_gates_are_fail_closed(self):
+        jobs = workflow("pages-publish.yml")["jobs"]
+        preview_if = normalized(jobs["preview"]["if"])
+        self.assertTrue(preview_if.startswith("vars.MAPLE_PAGES_PREVIEW_ENABLED == 'true' &&"))
+        for control in (
+            "github.event_name == 'workflow_run'",
+            "workflow_run.conclusion == 'success'",
+            "workflow_run.path == '.github/workflows/pages-preview-build.yml'",
+            "workflow_run.head_repository.full_name == github.repository",
+            "workflow_run.event == 'pull_request'",
+            "workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'master'",
+        ):
+            self.assertIn(control, preview_if)
+        production_if = normalized(jobs["production"]["if"])
+        self.assertTrue(production_if.startswith("vars.MAPLE_PAGES_PRODUCTION_ENABLED == 'true' &&"))
+        for control in (
+            "github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master'",
+            "github.event_name == 'workflow_run'",
+            "workflow_run.conclusion == 'success'",
+            "workflow_run.event == 'release'",
+            "workflow_run.path == '.github/workflows/release.yml'",
+            "workflow_run.head_repository.full_name == github.repository",
+        ):
+            self.assertIn(control, production_if)
+
+    def test_legacy_and_direct_production_have_one_rollout_switch_and_lock(self):
+        legacy = workflow("pages-production.yml")
+        direct = workflow("pages-publish.yml")["jobs"]["production"]
+        self.assertTrue(
+            normalized(legacy["jobs"]["promote"]["if"]).startswith(
+                "vars.MAPLE_PAGES_PRODUCTION_ENABLED != 'true' &&"
+            )
+        )
+        self.assertEqual(direct["concurrency"], legacy["concurrency"])
+        self.assertEqual(direct["concurrency"], {"group": "pages-production", "cancel-in-progress": False})
+        self.assertEqual(
+            workflow("pages-publish.yml")["jobs"]["preview"]["concurrency"],
+            {"group": "pages-preview-${{ github.event.workflow_run.head_branch }}", "cancel-in-progress": False},
+        )
+
+    def test_actions_are_immutable_and_nix_gets_no_github_token(self):
+        for name in ("pages-preview-build.yml", "pages-publish.yml", "pages-tests.yml"):
+            for job in workflow(name)["jobs"].values():
+                for step in job["steps"]:
+                    if "uses" not in step:
+                        continue
+                    with self.subTest(workflow=name, action=step["uses"]):
+                        self.assertRegex(step["uses"], r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[0-9a-f]{40}$")
+                        self.assertNotIn("actions/cache@", step["uses"])
+                        if step["uses"].startswith("DeterminateSystems/nix-installer-action@"):
+                            self.assertEqual(step["with"]["github-token"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Maple currently depends on Cloudflare's GitHub integration to build and publish its web app. This adds an opt-in publisher for the existing `maple` Pages project so the repository can move organizations without replacing the project or moving production domains.

Internal PRs and current master previews build with the existing development API, billing, flags and PCR profile. Stable releases publish the existing production-configured release archive without rebuilding. Both publishers default off; the existing production promoter remains active until the production flag is enabled.

### Security boundaries

- Separate unprivileged preview builds from publication running only trusted default-branch code. No PR checkout, dependencies, caches or scripts run with deployment credentials.
- Independently validate repository/workflow identities, event, successful run and attempt, current source ownership, exact artifacts and GitHub digests. Fork PRs cannot receive hosted previews.
- Bound and manually extract static archives; reject traversal, links, special files, configuration, Functions and Worker entry points. Preserve mobile association files under the exact root `.well-known` directory.
- Install pinned Wrangler from the trusted lockfile without lifecycle scripts before CF credentials enter the final step. Run it outside the checkout/artifact tree with a restricted environment and verify CF's completed deploy stage before reporting success.
- Gate publication on dedicated protected GitHub environments and separate opt-in variables. Reuse the production concurrency group, reject stale/non-forward releases, and refuse production uploads while native CF production builds remain enabled.

### Validation

- `nix flake check --no-update-lock-file` passed on aarch64-darwin, including 70 Pages tests and the existing workflow, release-gate, metadata, change-detection and toolchain checks.
- Development-profile `scripts/ci/web.sh` build passed.
- Both the actual development build and v3.3.10 release archives passed static extraction, including mobile association files.
- Read-only production preparation passed against the real successful v3.3.10 Release run and assets, including GitHub digests and the release checksum.
- Read-only preview preparation passed against final-commit `Pages preview build` run 34159293160, including current internal PR ownership, run/attempt, GitHub ZIP digest, manifest and static extraction. The real-artifact check caught and fixed the different media types required by the [Actions artifact](https://docs.github.com/en/rest/actions/artifacts#download-an-artifact) and [release asset](https://docs.github.com/en/rest/releases/assets#get-a-release-asset) endpoints.
- The commit hook passed frontend formatting/build and 818 tests. Final-commit GitHub checks passed all 70 Pages tests, web/preview builds, frontend, repository, updater Worker and release-gate checks. Native-platform and Rust checks were still running at handoff; this PR's checks show their current status.
- Independent adversarial review found no remaining blocking findings after the deployment-stage and `.well-known` fixes.

### Activation and limits

See [the deployment guide](docs/pages-deployments.md) for exact protected environments, Pages-only CI tokens, preview-first cutover and recovery steps. No environments, secrets, flags, Cloudflare settings, DNS or production deployments were changed for this implementation. The new publishers remain off; the existing Cloudflare integration still produces its ordinary PR preview.

Read-only setup audit: the Pages environments do not exist yet. Master's effective rules currently prevent deletion and non-fast-forward updates but do not require PR review. Configure master review protection and exact-master deployment policies before placing deployment credentials in the new environments.

CF Pages Edit tokens are account-scoped; they are not restricted to this project. Artifact consistency does not establish that PR JavaScript is honest. CF API verification does not prove Access, login, chat or browser environment behavior. A source change or reporting failure after an upload can leave that upload active; the guide records the explicit hold and production rollback procedure.
