### PR TITLE
test: verify owned Pages preview publishing

### DIFF
--- a/frontend/public/pages-preview-pilot.txt
+++ b/frontend/public/pages-preview-pilot.txt
@@ -1,0 +1,2 @@
+Maple Pages preview pilot
+marker 2026-09-07-owned-pages


### PR DESCRIPTION
This temporary draft PR exercises the internal-PR path of the new Maple Pages publisher. It adds only a harmless static text marker so the deployed preview can be checked against exact expected bytes.

Expected marker:

```text
Maple Pages preview pilot
marker 2026-09-07-owned-pages
```

The file is 56 bytes, SHA-256 `79c9509c66846be356b6471f400b1f458746afb86e1f2ebf02fa176f6a20a89b`.

Local formatting, TypeScript/Vite build, and 818 frontend tests passed. Preview publication is enabled; owned production publication remains disabled. Use the immutable deployment URL reported by `Publish Pages` when verifying this file, configuration and Access.

This PR is a pilot fixture and should not be merged. Keep it open through deployment and browser verification, then close it.
