### PR TITLE
Keep Pages deployment reporting on verified artifact commits

### DIFF
--- a/.github/workflows/pages-publish.yml
+++ b/.github/workflows/pages-publish.yml
@@ -27,6 +27,8 @@ jobs:
       cancel-in-progress: false
     environment:
       name: pages-preview
+      # The publisher reports the artifact SHA, not this job's master checkout SHA.
+      deployment: false
     permissions:
       contents: read
       actions: read
@@ -84,7 +86,8 @@ jobs:
       cancel-in-progress: false
     environment:
       name: pages-production
-      url: https://trymaple.ai
+      # Keep job completion from superseding the verified release deployment.
+      deployment: false
     permissions:
       contents: write
       actions: read

--- a/docs/pages-deployments.md
+++ b/docs/pages-deployments.md
@@ -141,6 +141,14 @@ That is deployment-state evidence, not an authenticated application smoke test.
 Access-protected previews require a permitted browser; an automated HTTP 403
 alone does not establish a broken application.
 
+Both publisher jobs keep their protected environments but set
+`environment.deployment: false`. This prevents GitHub's automatic job-completion
+record for the publisher's master checkout from superseding the deployment
+reported for the actual artifact SHA. The explicit deployment status owns the
+production/preview URL. Branch policies, reviewers, wait timers, and secrets still
+apply; custom deployment-protection GitHub Apps are incompatible with this mode
+and make the job fail. See [GitHub's environment-without-deployment rules](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments).
+
 GitHub and Cloudflare do not provide an atomic transaction here. If the source
 changes during upload, or later ref/status reporting fails, the new deployment
 can already be active even though the workflow fails. Inspect Cloudflare's actual

--- a/flake.nix
+++ b/flake.nix
@@ -686,7 +686,15 @@
             cd "$src"
             # actionlint 1.7.10 predates GitHub's supported concurrency.queue key.
             # Release-gate tests assert that the only intended value is queue: max.
-            actionlint -ignore 'unexpected key "queue" for "concurrency" section' ./*.yml
+            for workflow in ./*.yml; do
+              if [ "$workflow" = ./pages-publish.yml ]; then
+                # It also predates environment.deployment. Pages tests require
+                # false on both publisher jobs; keep this exception file-scoped.
+                actionlint -ignore 'unexpected key "deployment" for "environment" section' "$workflow"
+              else
+                actionlint -ignore 'unexpected key "queue" for "concurrency" section' "$workflow"
+              fi
+            done
             touch "$out"
           '';
 

--- a/scripts/ci/test_pages_deploy.py
+++ b/scripts/ci/test_pages_deploy.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import sys
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from urllib.error import HTTPError
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -29,6 +29,32 @@ class MemoryAPI:
         if method != "GET":
             raise AssertionError("Selection must never mutate GitHub")
         return copy.deepcopy(self.values[path])
+
+
+class DeploymentReportingTests(unittest.TestCase):
+    def test_reports_artifact_sha_when_publisher_checks_out_newer_master(self):
+        for target, branch, environment in (
+            ("production", "pages-production", "pages-production"),
+            ("preview", "master", "pages-master"),
+        ):
+            with self.subTest(target=target):
+                gh = Mock()
+                gh.write.return_value = {"id": 123}
+                plan = {"target": target, "branch": branch, "sha": SHA}
+                result = {"url": "https://12345678.maple-ca8.pages.dev"}
+                with patch.dict(os.environ, {"GITHUB_SHA": OTHER_SHA}):
+                    pages.report(gh, plan, result)
+                self.assertEqual(gh.write.call_count, 2)
+                creation, success = gh.write.call_args_list
+                self.assertEqual(creation.args[0], "/deployments")
+                self.assertEqual(creation.args[1]["ref"], SHA)
+                self.assertEqual(creation.args[1]["environment"], environment)
+                self.assertEqual(success.args[0], "/deployments/123/statuses")
+                self.assertEqual(success.args[1]["state"], "success")
+                self.assertEqual(
+                    success.args[1]["environment_url"],
+                    "https://trymaple.ai" if target == "production" else result["url"],
+                )
 
 
 class ProvenanceTests(unittest.TestCase):

--- a/scripts/ci/test_pages_workflows.py
+++ b/scripts/ci/test_pages_workflows.py
@@ -170,7 +170,12 @@ class PagesWorkflowTests(unittest.TestCase):
         for target, job in publish["jobs"].items():
             with self.subTest(target=target):
                 self.assertNotIn("env", job)
-                self.assertEqual(job["environment"]["name"], f"pages-{target}")
+                # GitHub's automatic job deployment uses the publisher checkout
+                # SHA and can inactivate the explicit artifact-SHA deployment.
+                self.assertEqual(
+                    job["environment"],
+                    {"name": f"pages-{target}", "deployment": False},
+                )
                 steps = job["steps"]
                 deploy = steps[-1]
                 self.assertEqual(


### PR DESCRIPTION
`Publish Pages` executes trusted master while uploading an independently verified preview or release artifact. GitHub's automatic environment deployment therefore records the publisher checkout SHA; its success at job completion can inactivate the explicit deployment for the artifact that is actually live.

Set `environment.deployment: false` on both publisher jobs so only the explicit artifact-SHA deployment is reported. The protected environment names, secrets, branch policies, permissions, provenance checks, and deployment URLs remain in place. [GitHub documents this behavior and its protection-rule constraints](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments); custom deployment-protection apps are incompatible and are documented accordingly.

Pinned actionlint 1.7.10 predates this field. Its exact unsupported-field diagnostic is suppressed only for `pages-publish.yml`; every other diagnostic remains active, and the workflow boundary test requires the exact environment mapping with `deployment: false`.

Validation:

- Full host `nix flake check --no-update-lock-file` passed, including 71 Pages tests, 27 release-gate cases, and workflow lint.
- Normal commit hooks passed frontend formatting, TypeScript/Vite build, and 818 frontend tests.
- Reporting regression checks verify the artifact SHA and target URL when the publisher's `GITHUB_SHA` is a newer master commit.

The revised workflow has not yet executed from protected master. This PR changes no production artifact or Cloudflare configuration; verifying that the explicit deployment stays active after job completion remains a post-merge check.
