### PR TITLE
Fix backend entropy test fixtures in the Nix sandbox

### DIFF
--- a/scripts/ci/opensecret_change_detection.py
+++ b/scripts/ci/opensecret_change_detection.py
@@ -19,6 +19,8 @@ PCR_INPUTS = frozenset({
     "pcrPreview.json", "pcrPreviewHistory.json", "pcr_verify.js", "pcr_sign.js",
     "scripts/pcr_compatibility.py", "scripts/test_pcr_compatibility.py",
 })
+# Shell test inputs consumed directly by the component flake, not Cargo.
+NIX_TEST_INPUTS = frozenset({"tests/entrypoint_entropy_preflight.sh"})
 BACKEND_INERT_PREFIXES = ("docs/", ".agents/", ".github/")
 SHARED_INPUTS = frozenset({
     ".gitmodules",
@@ -63,6 +65,8 @@ def classify_path(path: str) -> frozenset[str]:
             return ALL_OUTPUTS
         if relative.startswith(("src/", ".cargo/")) or relative == "build.rs":
             return frozenset({"rust", "nix", "integration"})
+        if relative in NIX_TEST_INPUTS:
+            return frozenset({"nix"})
         if relative.startswith(("tests/", "migrations/")):
             return frozenset({"rust", "integration"})
         if relative == ".env.sample":

--- a/scripts/ci/test_opensecret_change_detection.py
+++ b/scripts/ci/test_opensecret_change_detection.py
@@ -32,6 +32,12 @@ class OpenSecretChangeDetectionTests(unittest.TestCase):
                 self.assertEqual(research_routes(path), frozenset())
                 self.assertFalse(affects_agent(path))
 
+    def test_backend_flake_shell_test_selects_nix_without_rust_or_app_builds(self):
+        path = "services/opensecret/tests/entrypoint_entropy_preflight.sh"
+        self.assert_routes([path], "nix")
+        self.assertEqual(research_routes(path), frozenset())
+        self.assertFalse(affects_agent(path))
+
     def test_backend_nix_only_inputs_and_dependency_policy_keep_independent_checks(self):
         for relative in ("nix/kernel-upstream.nix", "entrypoint.sh", "continuum-proxy",
                          "nitro-toolkit", "nitro-toolkit/init/main.c", "privatemode-public"):

--- a/services/opensecret/tests/entrypoint_entropy_preflight.sh
+++ b/services/opensecret/tests/entrypoint_entropy_preflight.sh
@@ -27,17 +27,12 @@ if [ -z "$gate_line" ] || [ -z "$log_forwarder_line" ] || [ "$gate_line" -ge "$l
 fi
 
 pass_getrandom="$work_dir/pass-getrandom"
-cat > "$pass_getrandom" <<'EOF'
-#!/usr/bin/env bash
-exit 0
-EOF
+# The Nix sandbox has Bash in the store but no /usr/bin/env.
+printf '#!%s\nexit 0\n' "$BASH" > "$pass_getrandom"
 chmod +x "$pass_getrandom"
 
 fail_getrandom="$work_dir/fail-getrandom"
-cat > "$fail_getrandom" <<'EOF'
-#!/usr/bin/env bash
-exit 1
-EOF
+printf '#!%s\nexit 1\n' "$BASH" > "$fail_getrandom"
 chmod +x "$fail_getrandom"
 
 rng_current="$work_dir/rng_current"


### PR DESCRIPTION
The imported backend Nix check fails on Linux before exercising entropy behavior: its generated pass/fail `getrandom` fixtures use `#!/usr/bin/env bash`, while `/usr/bin/env` is absent in the Nix sandbox. This was inherited unchanged from OpenSecret and surfaced in [the import PR's Linux check](https://github.com/MaplePrivacyLabs/Maple/actions/runs/34252922933/job/102151571066).

Generate the two fixture shebangs with the absolute `$BASH` interpreter already executing the test. Preserve every entropy assertion and the production entrypoint. Also route the exact shell test consumed by the backend flake to the Nix CI lane; previously it selected only Rust/SDK checks as a generic `tests/` file. Add a regression proving Nix selection without app packaging.

Validation: 10 selector tests passed; the pinned backend-shell entropy test and rebuilt Darwin Nix entropy check passed; all 9 root flake checks passed. The normal pre-commit hook passed the frontend build and 818 tests. Hosted Linux verification is pending; the Darwin run alone does not prove the Linux sandbox fix. No backend production code, PCR values/signatures, dependency pins, EIFs, or deployment changed.

Follow-up to merged [#888](https://github.com/MaplePrivacyLabs/Maple/pull/888).
