### PR TITLE
Use canonical Maple PCR histories in both SDKs

### DIFF
--- a/.agents/skills/develop-opensecret-sdk/SKILL.md
+++ b/.agents/skills/develop-opensecret-sdk/SKILL.md
@@ -72,9 +72,12 @@ changes and run its component validation when the compatibility contract reaches
 them; there is no separate integration revision to advance.
 
 Provider-spending tests remain opt-in through `RUN_LIVE_AI=1` and require
-explicit credential, egress, and cost authorization. The SDKs retain their
-existing signed-PCR URLs until a separately verified canonical URL cutover;
-the backend import alone does not change installed clients' trust sources.
+explicit credential, egress, and cost authorization. Both SDKs use signed-PCR
+histories under `MaplePrivacyLabs/Maple/master/services/opensecret/`, with the
+existing verification key and separate development/production policies. Keep
+the legacy `OpenSecretCloud/opensecret` histories available for older clients
+through the backend's manual compatibility procedure. Source changes do not
+publish SDKs or update installed clients.
 
 Before handoff, inspect package boundaries as applicable:
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -30,7 +30,8 @@ for external users.
 
 For non-local endpoints, both SDKs require HTTPS, verify AWS Nitro attestation,
 and enforce an environment-scoped PCR0 trust policy before completing key
-exchange. Official PCR0 histories are signed and bundled with the SDKs.
+exchange. The SDKs bundle environment-specific PCR0 trust roots and the
+verification key used to authenticate signed remote history entries.
 
 Mock attestation is limited to exact loopback development endpoints (plus the
 documented Android emulator alias in the Rust SDK). Do not weaken attestation,
@@ -95,8 +96,14 @@ Tests that spend model/provider capacity are opt-in with `RUN_LIVE_AI=1` and
 are not part of the deterministic pull-request gate. Backend contract changes
 and SDK changes are validated together against that checkout; released clients
 and independently deployed backend versions still need compatibility review.
-The SDKs' existing signed-PCR URLs remain unchanged until a separate verified
-cutover. See the [backend compatibility procedure](../services/opensecret/docs/pcr-compatibility.md).
+Both SDKs fetch their selected environment's signed PCR history from
+`MaplePrivacyLabs/Maple/master/services/opensecret/`: `pcrProdHistory.json` for
+production and `pcrDevHistory.json` for development. The existing verification
+key, embedded roots, custom history URL overrides, and redirect rejection are
+unchanged. Older published SDKs and installed clients still use the legacy
+`OpenSecretCloud/opensecret` URLs, which remain a manual compatibility mirror.
+Changing source defaults does not update those clients or publish an SDK. See
+the [backend compatibility procedure](../services/opensecret/docs/pcr-compatibility.md).
 
 Inspect the publishable npm artifact with:
 

--- a/sdk/rust/src/pcr.rs
+++ b/sdk/rust/src/pcr.rs
@@ -23,9 +23,9 @@ const PCR_HISTORY_VERIFICATION_KEY_B64: &str =
     "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEHiUY9kFWK1GqBGzczohhwEwElXzgWLDZa9R6wBx3JOBocgSt9+UIzZlJbPDjYeGBfDUXh7Z62BG2vVsh2NgclLB5S7A2ucBBtb1wd8vSQHP8jpdPhZX1slauPgbnROIP";
 
 pub const OFFICIAL_PRODUCTION_PCR_HISTORY_URL: &str =
-    "https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrProdHistory.json";
+    "https://raw.githubusercontent.com/MaplePrivacyLabs/Maple/master/services/opensecret/pcrProdHistory.json";
 pub const OFFICIAL_DEVELOPMENT_PCR_HISTORY_URL: &str =
-    "https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrDevHistory.json";
+    "https://raw.githubusercontent.com/MaplePrivacyLabs/Maple/master/services/opensecret/pcrDevHistory.json";
 
 const OFFICIAL_PRODUCTION_PCR0S: &[&str] = &[
     "eeddbb58f57c38894d6d5af5e575fbe791c5bf3bbcfb5df8da8cfcf0c2e1da1913108e6a762112444740b88c163d7f4b",

--- a/sdk/src/lib/pcr.ts
+++ b/sdk/src/lib/pcr.ts
@@ -31,11 +31,11 @@ const PCR_VERIFICATION_PUBLIC_KEY_B64 =
   "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEHiUY9kFWK1GqBGzczohhwEwElXzgWLDZa9R6wBx3JOBocgSt9+UIzZlJbPDjYeGBfDUXh7Z62BG2vVsh2NgclLB5S7A2ucBBtb1wd8vSQHP8jpdPhZX1slauPgbnROIP";
 
 /**
- * Remote PCR history URLs
+ * Canonical signed PCR histories in the Maple monorepo.
  */
 const PCR_HISTORY_URLS = {
-  prod: "https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrProdHistory.json",
-  dev: "https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrDevHistory.json"
+  prod: "https://raw.githubusercontent.com/MaplePrivacyLabs/Maple/master/services/opensecret/pcrProdHistory.json",
+  dev: "https://raw.githubusercontent.com/MaplePrivacyLabs/Maple/master/services/opensecret/pcrDevHistory.json"
 };
 
 const PCR0_HEX_LENGTH = 96;

--- a/sdk/src/lib/test/customFetch.test.ts
+++ b/sdk/src/lib/test/customFetch.test.ts
@@ -1473,8 +1473,8 @@ describe("createCustomFetch stale-session recovery", () => {
       pcr0DevValues: ["2a".repeat(48)],
       remoteAttestation: false,
       remoteAttestationUrls: {
-        prod: "https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrProdHistory.json",
-        dev: "https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrDevHistory.json"
+        prod: "https://raw.githubusercontent.com/MaplePrivacyLabs/Maple/master/services/opensecret/pcrProdHistory.json",
+        dev: "https://raw.githubusercontent.com/MaplePrivacyLabs/Maple/master/services/opensecret/pcrDevHistory.json"
       }
     };
     const calls: Array<[boolean | undefined, string | undefined, PcrConfig | undefined]> = [];

--- a/sdk/src/lib/test/integration/pcr.test.ts
+++ b/sdk/src/lib/test/integration/pcr.test.ts
@@ -186,7 +186,9 @@ test("validates PCR0 from only the selected production history by default", asyn
     async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
       const url =
         typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-      expect(url).toContain("pcrProdHistory.json");
+      expect(url).toBe(
+        "https://raw.githubusercontent.com/MaplePrivacyLabs/Maple/master/services/opensecret/pcrProdHistory.json"
+      );
       return createMockResponse([
         {
           PCR0: VERIFIED_PCR0,
@@ -216,7 +218,9 @@ test("validates PCR0 from only the selected development history", async () => {
     async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
       const url =
         typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-      expect(url).toContain("pcrDevHistory.json");
+      expect(url).toBe(
+        "https://raw.githubusercontent.com/MaplePrivacyLabs/Maple/master/services/opensecret/pcrDevHistory.json"
+      );
       return createMockResponse([
         {
           PCR0: VERIFIED_PCR0,

--- a/services/opensecret/docs/pcr-compatibility.md
+++ b/services/opensecret/docs/pcr-compatibility.md
@@ -34,17 +34,18 @@ repository move or redirect is not a substitute: current TypeScript and Rust
 SDK history fetches reject redirects. Existing clients continue to use the old
 URLs; they do not discover the monorepo layout automatically.
 
-After the import is merged, verify the new public history URLs return HTTP 200
-directly and exactly match the reviewed monorepo files before changing SDK
-defaults in a follow-up:
+The in-tree TypeScript and Rust SDK defaults use these canonical histories:
 
-- [New development history](https://raw.githubusercontent.com/MaplePrivacyLabs/Maple/master/services/opensecret/pcrDevHistory.json)
-- [New production history](https://raw.githubusercontent.com/MaplePrivacyLabs/Maple/master/services/opensecret/pcrProdHistory.json)
+- [Canonical development history](https://raw.githubusercontent.com/MaplePrivacyLabs/Maple/master/services/opensecret/pcrDevHistory.json)
+- [Canonical production history](https://raw.githubusercontent.com/MaplePrivacyLabs/Maple/master/services/opensecret/pcrProdHistory.json)
 
-SDK URL changes are independent of registry renaming or publishing. Until that
-follow-up is merged, SDK source defaults still use the old URLs. Do not remove
-the legacy history or set a calendar cutoff as a consequence of this import.
-An eventual cutoff needs an explicit client compatibility decision.
+Both locations must return HTTP 200 directly and match the reviewed files;
+use the verification procedure below for every authorized measurement update.
+SDK URL changes are independent of registry renaming or publishing. Older
+published SDKs and installed clients retain their existing URLs until upgraded.
+Do not remove the legacy history or set a calendar cutoff as a consequence of
+the source cutover. An eventual cutoff needs an explicit client compatibility
+decision.
 
 ## Validate an authorized measurement update
 


### PR DESCRIPTION
Both SDKs currently fetch signed PCR histories from the legacy backend repository. Switch their production and development defaults to `MaplePrivacyLabs/Maple/master/services/opensecret/`, where the backend import now maintains the same files.

The verification key, embedded PCR0 roots, environment separation, custom URL overrides, caching, bounds, and redirect rejection remain unchanged. Keep the legacy repository's existing URLs and manual signed-file mirror for installed clients. This PR changes source defaults; it does not publish packages or deploy the backend.

Validation:

- All four public files at both master and immutable URLs in both repositories: 16 direct HTTP 200 responses, byte-identical to reviewed Maple commit `79385743c0a4e17d0f06a4a5fcf8240256448574`; all 290 existing PCR0 signatures verified.
- TypeScript: formatting/build, 123 tests passed and 3 hosted-enclave tests skipped, package inventory and both generated JS formats checked. Live SDK history fetches verified a non-embedded signed PCR0 through each new default URL.
- Rust: formatting, clippy, 85 library tests, rustdoc, crate packaging/build, and in-tree dependency graph verification passed.
- Normal pre-commit gate: Research web build and 818 tests passed. Independent diff review found no introduced issues.

The branch now incorporates merged [PR #892](https://github.com/MaplePrivacyLabs/Maple/pull/892), which patches fast-uri and corrects SDK workflow failure propagation, and [PR #889](https://github.com/MaplePrivacyLabs/Maple/pull/889), the backend Nix fixture fix. The diff against master remains the seven-file PCR URL/documentation change. The combined tree passed all nine root flake checks, TypeScript formatting/build and 123 tests (3 hosted tests skipped), and the normal Research build/818-test commit gate.

A fresh audit now reports [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh) in the unchanged `eslint -> @eslint/eslintrc -> js-yaml@4.3.1` development-tool chain. This advisory entered GitHub's database on 2026-09-08 at 21:24 UTC and was not reported in the earlier green SDK job. The current lockfiles match master; this PCR change does not introduce the dependency. Independent dependency-closure review found no js-yaml in the SDK or Research production closures. The audit remains enforced and fails until the separate dependency follow-up patches it. Functional validation after that failed audit was run separately; it is not a clean-audit claim.

The original hosted run passed Research desktop builds and SDK integration; its only job failure was the unchanged Agent macOS subprocess fixture's 0.5-second deadline. The user explicitly accepted that Agent failure for this merge and requested a separate follow-up PR next round. Refreshed/full post-merge hosted builds are separate from the local validation above.
