### PR TITLE
Fail SDK CI on unsuccessful checks and patch fast-uri

### DIFF
--- a/.agents/skills/develop-opensecret-sdk/SKILL.md
+++ b/.agents/skills/develop-opensecret-sdk/SKILL.md
@@ -54,6 +54,7 @@ For Rust work:
 
 ```sh
 nix develop --no-update-lock-file -c bash -lc '
+  set -euo pipefail
   cd rust
   cargo fmt --all -- --check
   cargo clippy --locked --all-targets --all-features -- -D warnings

--- a/.github/workflows/sdk-rust.yml
+++ b/.github/workflows/sdk-rust.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Run credential-free Rust SDK checks
         run: |
           nix develop --no-update-lock-file ./sdk -c bash -lc '
+            set -euo pipefail
             cd sdk/rust
             cargo fmt --all -- --check
             cargo clippy --locked --all-targets --all-features -- -D warnings

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Run credential-free TypeScript SDK checks
         run: |
           nix develop --no-update-lock-file ./sdk -c bash -lc '
+            set -euo pipefail
             cd sdk
             bun install --frozen-lockfile --ignore-scripts
             bun audit --audit-level=high

--- a/apps/maple-research/frontend/bun.lock
+++ b/apps/maple-research/frontend/bun.lock
@@ -745,7 +745,7 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fastq": ["fastq@1.19.0", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA=="],
 

--- a/scripts/ci/test_opensecret_workflows.py
+++ b/scripts/ci/test_opensecret_workflows.py
@@ -4,8 +4,10 @@ import functools
 import json
 import os
 from pathlib import Path
+import shlex
 import shutil
 import subprocess
+import sys
 import tempfile
 import tomllib
 import unittest
@@ -161,6 +163,73 @@ class OpenSecretWorkflowBoundaryTests(unittest.TestCase):
                 self.assertIn("always() && !cancelled()", condition)
                 self.assertIn("needs.changes.result != 'success'", condition)
                 self.assertIn(f"needs.changes.outputs.{output} != 'false'", condition)
+
+
+class SdkWorkflowFailurePropagationTests(unittest.TestCase):
+    CHECKS = (
+        ("sdk-typescript.yml", "sdk-typescript", (
+            "bun install", "bun audit", "bun run format:check", "bun run build", "bun test",
+        )),
+        ("sdk-rust.yml", "sdk-rust", (
+            "cargo fmt", "cargo clippy", "cargo test", "cargo doc",
+        )),
+    )
+
+    def run_checks(self, name, job, failure=""):
+        steps = [step["run"] for step in workflow(name)["jobs"][job]["steps"] if "run" in step]
+        # Execute the actual nested shell body, without letting an outer -e or
+        # host login profile accidentally supply the workflow's missing guard.
+        self.assertEqual(len(steps), 1)
+        command = shlex.split(steps[0])
+        self.assertEqual(command[:-1], [
+            "nix", "develop", "--no-update-lock-file", "./sdk", "-c", "bash", "-lc",
+        ])
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "sdk/rust").mkdir(parents=True)
+            binaries = root / "bin"
+            binaries.mkdir()
+            trace = root / "commands"
+            for tool in ("bun", "cargo"):
+                stub = binaries / tool
+                stub.write_text(
+                    f"#!{sys.executable}\n"
+                    "import os, sys\n"
+                    "from pathlib import Path\n"
+                    "command = ' '.join([Path(sys.argv[0]).name, *sys.argv[1:]])\n"
+                    "with open(os.environ['SDK_CHECK_TRACE'], 'a') as trace:\n"
+                    "    trace.write(command + '\\n')\n"
+                    "failure = os.environ['SDK_CHECK_FAILURE']\n"
+                    "sys.exit(42 if failure and command.startswith(failure) else 0)\n"
+                )
+                stub.chmod(0o755)
+            result = subprocess.run(
+                [shutil.which("bash"), "--noprofile", "--norc", "-c", command[-1]],
+                cwd=root,
+                env={"PATH": str(binaries), "HOME": temporary,
+                     "SDK_CHECK_TRACE": str(trace), "SDK_CHECK_FAILURE": failure},
+                capture_output=True, text=True,
+            )
+            return result, trace.read_text().splitlines() if trace.exists() else []
+
+    def test_each_failed_sdk_check_stops_the_workflow(self):
+        for name, job, checks in self.CHECKS:
+            for index, failure in enumerate(checks):
+                with self.subTest(workflow=name, failure=failure):
+                    result, commands = self.run_checks(name, job, failure)
+                    self.assertEqual(result.returncode, 42, result.stderr)
+                    self.assertEqual(len(commands), index + 1, commands)
+                    for command, expected in zip(commands, checks):
+                        self.assertTrue(command.startswith(expected), command)
+
+    def test_successful_sdk_checks_all_execute(self):
+        for name, job, checks in self.CHECKS:
+            with self.subTest(workflow=name):
+                result, commands = self.run_checks(name, job)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(len(commands), len(checks), commands)
+                for command, expected in zip(commands, checks):
+                    self.assertTrue(command.startswith(expected), command)
 
 
 class OpenSecretDiffSelectionTests(unittest.TestCase):

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -128,6 +128,7 @@ Run the Rust validation from the `sdk/` directory:
 
 ```sh
 nix develop --no-update-lock-file -c bash -lc '
+  set -euo pipefail
   cd rust
   cargo fmt --all -- --check
   cargo clippy --locked --all-targets --all-features -- -D warnings

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -447,7 +447,7 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 


### PR DESCRIPTION
SDK checks can report success after an earlier command fails: the nested shells in the TypeScript and Rust workflows do not enable failure propagation. [This hosted TypeScript run](https://github.com/MaplePrivacyLabs/Maple/actions/runs/34282357054/job/102249881281) printed four high-severity audit findings, continued through the remaining commands, and finished green.

Enable strict mode inside both nested shells so failed installs, audits, formatting, builds, clippy, or tests fail the job immediately. Update the two documented Rust command sequences to match. Workflow permissions, triggers, and credential boundaries remain unchanged.

Also patch the reported `ajv -> fast-uri@3.1.5` development dependency to 3.1.7 in both active Bun lockfiles; Research independently locks the linked SDK's tooling. These dependency changes are two resolution lines with registry-verified integrity and no manifest, runtime, or release-age policy changes.

Use 3.1.7 because the newer upstream advisories also affect 3.1.6: [GHSA-58mr-gqgx-xq4g](https://github.com/fastify/fast-uri/security/advisories/GHSA-58mr-gqgx-xq4g) and [GHSA-qw65-cvwx-89v3](https://github.com/fastify/fast-uri/security/advisories/GHSA-qw65-cvwx-89v3).

Validation:

- Regression tests execute the actual YAML shell bodies with failing command stubs and clean environments. Before the fix, seven earlier command failures were masked. After the fix, all nine failure cases stop with the original exit status, and both successful sequences execute every check. All 14 tests in the existing OpenSecret/SDK workflow suite pass.
- All nine root Nix flake checks pass on aarch64-darwin, including actionlint and the new regression tests inside the Nix sandbox.
- Normal frozen installs pass; SDK audit reports zero vulnerabilities; the exact TypeScript workflow shell passes formatting/build and 123 tests (3 hosted tests skipped). Package inspection confirms the six intended files.
- Research formatting/build and 818 tests pass. Independent dependency and workflow reviews found no issues.

This identified security patch used a one-time release-age exception during resolution generation. The repository's seven-day policy remains unchanged, and normal frozen installs accept the resulting locks. Unrelated Research tooling advisories and the alternate legacy SDK npm lock remain separate cleanup work; this PR fixes the active Bun graphs. No package is published by this change.
