### PR TITLE
Stabilize Agent login-shell output cleanup regression

### DIFF
--- a/apps/maple-agent/crates/maple-agent/src/agent/macos_login_path.rs
+++ b/apps/maple-agent/crates/maple-agent/src/agent/macos_login_path.rs
@@ -529,15 +529,20 @@ for raw_line in sys.stdin:
         write_executable(
             &shell,
             r#"#!/bin/sh
-fixture_root=$(/usr/bin/dirname "$0")
+fixture_root=${0%/*}
 /bin/sleep 30 &
 printf '%s\n' "$!" > "$fixture_root/same-group-child.pid"
-export PATH="/usr/bin:/bin:/usr/sbin:/sbin"
-/bin/sh -c "$4"
+printf '%s\n' "$MAPLE_LOGIN_SHELL_PATH_MARKER" '/usr/bin:/bin:/usr/sbin:/sbin'
+exit 0
 "#,
         );
 
-        let result = query_login_shell_search_paths(&shell, Duration::from_millis(500)).await;
+        // This tests output cleanup after the leader exits, not how quickly macOS can start
+        // several processes. Keep the fixture to shell builtins and the intentional stdout
+        // holder, and allow the normal probe budget for a busy hosted runner to reap the leader.
+        let started = Instant::now();
+        let result = query_login_shell_search_paths(&shell, LOGIN_SHELL_PATH_TIMEOUT).await;
+        let elapsed = started.elapsed();
         let pid = fs::read_to_string(pid_file)
             .unwrap()
             .trim()
@@ -557,6 +562,10 @@ export PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
         let error = result.unwrap_err();
         assert!(error.contains("output did not close"), "{error}");
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "probe waited for the stdout holder instead of its deadline: {elapsed:?}"
+        );
         assert!(stopped, "same-process-group child {pid} survived cleanup");
     }
 


### PR DESCRIPTION
The macOS output-timeout regression could fail during shell startup on a busy
runner because its 500 ms budget included four unnecessary helper processes.
Keep the fixture to shell builtins plus the intentional stdout holder and use
the normal five-second probe allowance, so it reaches the output-cleanup branch
it is intended to test.

The test still requires the specific output-timeout error and verifies that
production cleanup kills the same-process-group descendant. It also checks that
the probe returns before the holder's natural lifetime. Production code and
deadlines are unchanged.

Validation on macOS: ten focused repetitions and all five active login-path
regressions passed. Agent `just ci` passed, including all four Clippy
feature combinations, the warning-denied all-target workspace build, 725
workspace tests, and 30 headless tests. The three existing workspace ignores
are unchanged. Independent source review found no issues.

Hosted macOS CI also passed before merge. Local build/tests used pinned Rust
1.98.0. A later tool-version check found Cargo's formatter/Clippy lookup used
rustup's installed 1.97.1; corrected pinned subcommand validation is recorded
with the combined SDK rename in #895. No global toolchain configuration changed.
