### PR TITLE
Rename SDKs to @mapleai/sdk and maple-sdk

### DIFF
--- a/.agents/skills/change-maple-agent-mode/SKILL.md
+++ b/.agents/skills/change-maple-agent-mode/SKILL.md
@@ -19,7 +19,7 @@ Do not commit, push, open a PR, merge, release, or clean unrelated work unless t
 
 Keep Maple's two inference paths distinct:
 
-- Research chat is a browser-capable React path. `UnifiedChat.tsx` uses the OpenAI JavaScript client with `@opensecret/react`'s authenticated and encrypted `aiCustomFetch`, targeting OpenSecret's Conversations and Responses APIs.
+- Research chat is a browser-capable React path. `UnifiedChat.tsx` uses the OpenAI JavaScript client with `@mapleai/sdk`'s authenticated and encrypted `aiCustomFetch`, targeting OpenSecret's Conversations and Responses APIs.
 - Agent Mode is desktop-only. `AgentMode.tsx` calls typed frontend services, which invoke Tauri commands and receive `agent-event` envelopes. Native Rust owns `MapleAgentService`, the embedded Goose managers and local sessions, Maple's provider, developer tools, permissions, and cancellation. `MapleProvider` sends encrypted OpenSecret SDK requests to `/v1/chat/completions`.
 - ACP is a secondary local adapter over the same `MapleAgentService`. It must not initialize a second Goose runtime or call through the Tauri adapter.
 - The local OpenAI-compatible proxy is a separate user-facing feature. Neither Research chat nor Agent Mode should silently route through it.

--- a/.agents/skills/develop-maple-agent/SKILL.md
+++ b/.agents/skills/develop-maple-agent/SKILL.md
@@ -13,8 +13,8 @@ identify an arbitrary running development instance.
 `app/src/backend.rs` adapts the transport-neutral runtime under
 `crates/maple-agent/` to GPUI. Keep window/UI concerns in `app`, and shared
 account/session/tool policy in the runtime. The runtime consumes the existing
-local `opensecret` SDK and `maple-proxy`; registry names and publication are
-separate work. Research's Tauri runtime remains independently owned.
+local `maple-sdk` and `maple-proxy` packages; registry publication is separate
+work. Research's Tauri runtime remains independently owned.
 
 ## Build with the component environment
 

--- a/.agents/skills/develop-maple-proxy/SKILL.md
+++ b/.agents/skills/develop-maple-proxy/SKILL.md
@@ -101,7 +101,7 @@ publish, inspect the exact package first:
 cargo package --locked --manifest-path proxy/Cargo.toml
 ```
 
-If the proxy references a new `opensecret` version, publish that SDK crate
+If the proxy references a new `maple-sdk` version, publish that SDK crate
 first. Do not publish either crate from Maple's application Release workflow.
 Root proxy container CI builds without pushing. After a successful stable Maple
 Release, `.github/workflows/proxy-publish.yml` independently compares that

--- a/.agents/skills/develop-maple/SKILL.md
+++ b/.agents/skills/develop-maple/SKILL.md
@@ -78,7 +78,7 @@ through their public API URLs; do not depend on their source trees.
 
 - Put React, routes, contexts, and browser-facing services under `apps/maple-research/frontend/src/`.
 - Put privileged/native behavior under `apps/maple-research/frontend/src-tauri/src/` and expose the narrowest typed Tauri command or event needed by the UI.
-- Use `@opensecret/react` and the existing OpenSecret client paths for authentication, encryption, and API calls. Read `apps/maple-research/frontend/package.json` to determine whether the application consumes a published version or the in-tree `file:../../../sdk` package; do not infer that boundary from prose. Do not duplicate protocol or cryptographic logic in components.
+- Use `@mapleai/sdk` and the existing OpenSecret client paths for authentication, encryption, and API calls. Read `apps/maple-research/frontend/package.json` to determine whether the application consumes a published version or the in-tree `file:../../../sdk` package; do not infer that boundary from prose. Do not duplicate protocol or cryptographic logic in components.
 - Follow nearby state ownership, cancellation, error, and cleanup patterns. Preserve account isolation and handle logout, navigation, retries, and stale async completion explicitly.
 - Treat all network, file, deep-link, shell, tool, and Tauri-command inputs as untrusted. Validate again at the enforcing boundary.
 - Keep feature flags as rollout/UI controls, never authorization controls.

--- a/.agents/skills/develop-opensecret-sdk/SKILL.md
+++ b/.agents/skills/develop-opensecret-sdk/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: develop-opensecret-sdk
-description: Develop and review the OpenSecret TypeScript/React and Rust SDKs under Maple's sdk directory. Use for SDK API, authentication, attestation, encrypted transport, tests, in-tree OpenSecret integration, package contents, versions, or an explicitly authorized npm or crates.io publishing handoff; use develop-maple for application-only work.
+description: Develop and review the Maple TypeScript/React and Rust SDKs under Maple's sdk directory. Use for SDK API, authentication, attestation, encrypted transport, tests, in-tree OpenSecret integration, package contents, versions, or an explicitly authorized npm or crates.io publishing handoff; use develop-maple for application-only work.
 ---
 
-# Develop the OpenSecret SDK
+# Develop the Maple SDK
 
 Work from `MaplePrivacyLabs/Maple/sdk`. Read the repository-root `AGENTS.md`,
 `sdk/README.md`, the affected implementation and tests, and the root
@@ -12,8 +12,8 @@ Work from `MaplePrivacyLabs/Maple/sdk`. Read the repository-root `AGENTS.md`,
 The SDK source is part of the Maple repository, but its TypeScript and Rust
 package boundaries remain independently versioned and publishable:
 
-- `src/` builds `@opensecret/react` for browser and React consumers.
-- `rust/` builds the `opensecret` crate for native consumers.
+- `src/` builds `@mapleai/sdk` for browser and React consumers.
+- `rust/` builds the `maple-sdk` crate (imported as `maple_sdk`) for native consumers.
 - `apps/maple-research/frontend/package.json` is authoritative for whether Maple's browser client
   consumes a published TypeScript version or the in-tree `file:../../../sdk` package.
 - desktop Maple and `proxy/` consume the in-tree Rust crate through versioned

--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -26,7 +26,7 @@ commit, external effect, and authority provided by the user.
 - The same Maple GitHub Release receives four native `maple-proxy` archives and
   their checksum manifest. Never create a separate proxy Release or proxy tag;
   `/releases/latest` must continue to identify the Maple application release.
-- Maple GitHub Releases do not publish `opensecret` or `maple-proxy` to
+- Maple GitHub Releases do not publish `maple-sdk` or `maple-proxy` to
   crates.io. A successful stable release starts a non-gating GHCR sibling that
   builds only for a new or missing non-baseline proxy version. It treats exact
   version tags as immutable, verifies release provenance and container inputs,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ current source and tests take precedence over historical design documents.
 - `apps/maple-agent/`: GPUI desktop-v2 prototype, ACP and proxy CLI. Read its
   [guide](apps/maple-agent/AGENTS.md) and `$develop-maple-agent`. Its runtime and
   update discovery are separate from Research and its existing Agent Mode.
-- `sdk/`: TypeScript/React and Rust OpenSecret SDKs. Read
+- `sdk/`: TypeScript/React and Rust Maple SDKs for the OpenSecret backend. Read
   `$develop-opensecret-sdk` and the SDK documentation.
 - `proxy/`: the separate OpenAI-compatible relay, also consumed by the desktop
   app. Read `$develop-maple-proxy` and the proxy documentation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Maple
 
-Maple is a monorepo for the Maple applications, their OpenSecret SDKs, local proxy,
+Maple is a monorepo for the Maple applications, Maple SDKs, local proxy,
 OpenSecret backend, and updater service. The existing web, desktop, and mobile client lives under
 [`apps/maple-research/`](apps/maple-research/README.md), including Research chat
 and desktop Agent Mode. Its directory name does not change the shipped Maple
@@ -12,7 +12,7 @@ application identity.
 | --- | --- |
 | [`apps/maple-research/`](apps/maple-research/README.md) | React/Vite frontend and Tauri desktop/mobile application, app documentation, and distribution configuration |
 | [`apps/maple-agent/`](apps/maple-agent/README.md) | GPUI desktop-v2 prototype, ACP agent, and CLI proxy; independent from the shipped Research app |
-| [`sdk/`](sdk/README.md) | OpenSecret TypeScript/React and Rust SDKs, consumed in tree by Maple |
+| [`sdk/`](sdk/README.md) | Maple TypeScript/React and Rust SDKs, consumed in tree by Maple |
 | [`proxy/`](proxy/README.md) | Standalone OpenAI-compatible proxy, also consumed by desktop Maple |
 | [`services/updates/`](services/updates/README.md) | Desktop updater Worker and verified release-metadata publishing |
 | [`services/opensecret/`](services/opensecret/README.md) | Confidential authentication, inference, conversations, and related backend APIs; local Nitro tooling and signed PCR files |

--- a/apps/maple-agent/Cargo.lock
+++ b/apps/maple-agent/Cargo.lock
@@ -5821,8 +5821,8 @@ dependencies = [
  "libc",
  "log",
  "maple-proxy",
+ "maple-sdk",
  "once_cell",
- "opensecret",
  "process-wrap",
  "pulldown-cmark",
  "rand 0.8.7",
@@ -5866,8 +5866,8 @@ dependencies = [
  "maple-agent",
  "maple-billing",
  "maple-proxy",
+ "maple-sdk",
  "notify",
- "opensecret",
  "parking_lot",
  "percent-encoding",
  "pulldown-cmark",
@@ -5899,7 +5899,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "http",
- "opensecret",
+ "maple-sdk",
  "serde",
  "serde_json",
  "tokio",
@@ -5907,6 +5907,41 @@ dependencies = [
  "tower-http 0.6.11",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "maple-sdk"
+version = "3.6.2"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chacha20poly1305 0.10.1",
+ "chrono",
+ "ciborium",
+ "eventsource-stream",
+ "futures",
+ "hex",
+ "hkdf 0.12.4",
+ "http",
+ "p256",
+ "percent-encoding",
+ "pin-project",
+ "reqwest 0.12.28",
+ "ring",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "uuid",
+ "x25519-dalek",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -6968,41 +7003,6 @@ checksum = "7c603ab8300cf18bc3b14146b19fe3dfcc4843ae5a400cd0e7a30b95aa366634"
 dependencies = [
  "is-wsl",
  "libc",
-]
-
-[[package]]
-name = "opensecret"
-version = "3.6.2"
-dependencies = [
- "aes-gcm",
- "anyhow",
- "async-stream",
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "chacha20poly1305 0.10.1",
- "chrono",
- "ciborium",
- "eventsource-stream",
- "futures",
- "hex",
- "hkdf 0.12.4",
- "http",
- "p256",
- "percent-encoding",
- "pin-project",
- "reqwest 0.12.28",
- "ring",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "tokio",
- "tracing",
- "uuid",
- "x25519-dalek",
- "x509-parser",
- "yasna",
 ]
 
 [[package]]

--- a/apps/maple-agent/Cargo.toml
+++ b/apps/maple-agent/Cargo.toml
@@ -20,7 +20,7 @@ once_cell = "1.18.0"
 http = "1"
 reqwest = { version = "0.13", features = ["stream"] }
 # Shared monorepo crates retain their independent package names and versions.
-opensecret = { version = "3.6.2", path = "../../sdk/rust" }
+maple-sdk = { version = "3.6.2", path = "../../sdk/rust" }
 maple-proxy = { version = "0.3.4", path = "../../proxy" }
 
 [profile.dev]

--- a/apps/maple-agent/README.md
+++ b/apps/maple-agent/README.md
@@ -15,7 +15,7 @@ app/                  The maple-gpui binary. Owns the window, login, chat,
                       settings, notifications, and the backend adapter.
 crates/maple-agent/   Maple's transport-neutral agent runtime, extracted from
                       the Tauri app with Tauri removed. Owns embedded Goose,
-                      the Maple provider over the OpenSecret SDK, developer
+                      the Maple provider over the Maple Rust SDK, developer
                       tools, permission policy, account-scoped session
                       storage, and the ACP server.
 crates/maple-billing/ HTTP client for the Maple billing API.
@@ -450,9 +450,9 @@ the namespace. Local `just release` and `just dist` only build local files.
 
 ## Shared dependencies and provenance
 
-The component consumes the existing in-tree `opensecret` SDK at `../../sdk/rust`
+The component consumes the in-tree `maple-sdk` crate at `../../sdk/rust`
 and `maple-proxy` at `../../proxy` through workspace dependencies. The SDK fork
-patch is removed; no SDK rename or registry publication is needed for local
+patch is removed; registry publication is not needed for local
 builds. Keep the component lockfile and Nix source fileset aligned with these
 path dependencies. The pure package includes the required SDK attestation
 assets as well as Rust source.

--- a/apps/maple-agent/app/Cargo.toml
+++ b/apps/maple-agent/app/Cargo.toml
@@ -52,7 +52,7 @@ semver = "1"
 log = { workspace = true }
 env_logger = "0.11"
 webbrowser = "1"
-opensecret = { workspace = true }
+maple-sdk = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 unicode-segmentation = { version = "1", optional = true }
 pulldown-cmark = { version = "0.13", default-features = false, optional = true }

--- a/apps/maple-agent/app/src/backend.rs
+++ b/apps/maple-agent/app/src/backend.rs
@@ -30,7 +30,7 @@ use maple_agent::maple_api::{
     MapleApiAuthEventSink, MapleApiAuthRequest, MapleApiAuthSnapshot, MapleApiAuthState,
 };
 use maple_agent::open_secret_config::configured_pcr0_environment;
-use opensecret::OpenSecretClient;
+use maple_sdk::OpenSecretClient;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 use uuid::Uuid;

--- a/apps/maple-agent/crates/maple-agent/Cargo.toml
+++ b/apps/maple-agent/crates/maple-agent/Cargo.toml
@@ -25,7 +25,7 @@ reqwest = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 goose = { git = "https://github.com/AnthonyRonning/goose.git", rev = "785d655d110746147117d23690e09cc7023aa9dc", package = "goose", default-features = false }
 goose-providers = { git = "https://github.com/AnthonyRonning/goose.git", rev = "785d655d110746147117d23690e09cc7023aa9dc", package = "goose-providers", default-features = false }
-opensecret = { workspace = true }
+maple-sdk = { workspace = true }
 maple-proxy = { workspace = true }
 rand = "0.8.6"
 rmcp = { version = "=3.1.2", default-features = false, features = ["client", "transport-streamable-http-client-reqwest"] }

--- a/apps/maple-agent/crates/maple-agent/src/agent.rs
+++ b/apps/maple-agent/crates/maple-agent/src/agent.rs
@@ -4564,7 +4564,7 @@ static MODEL_CATALOG_REFRESH_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
 /// Resolve the catalog's vision flag without inventing one when metadata is absent.
 /// An explicit alias capability (including false) overrides its target model.
 fn catalog_supports_vision(
-    catalog: &opensecret::ModelCatalogResponse,
+    catalog: &maple_sdk::ModelCatalogResponse,
     model_id: &str,
 ) -> Option<bool> {
     let mut concrete_id = model_id;
@@ -10284,10 +10284,10 @@ mod tests {
     impl provider::MapleInferenceTransport for InertMapleTransport {
         async fn send_inference_request(
             self: Arc<Self>,
-            _request: opensecret::InferenceRequest,
+            _request: maple_sdk::InferenceRequest,
             _cancel_token: CancellationToken,
-        ) -> opensecret::Result<opensecret::InferenceResponse> {
-            Err(opensecret::Error::Other(
+        ) -> maple_sdk::Result<maple_sdk::InferenceResponse> {
+            Err(maple_sdk::Error::Other(
                 "test transport should not be called".to_string(),
             ))
         }
@@ -10305,15 +10305,15 @@ mod tests {
     impl provider::MapleInferenceTransport for TerminalMapleTransport {
         async fn send_inference_request(
             self: Arc<Self>,
-            _request: opensecret::InferenceRequest,
+            _request: maple_sdk::InferenceRequest,
             _cancel_token: CancellationToken,
-        ) -> opensecret::Result<opensecret::InferenceResponse> {
+        ) -> maple_sdk::Result<maple_sdk::InferenceResponse> {
             match self.0 {
-                TerminalMapleFailure::Session => Err(opensecret::Error::Session(
+                TerminalMapleFailure::Session => Err(maple_sdk::Error::Session(
                     "private exhausted session detail".to_string(),
                 )),
                 TerminalMapleFailure::AttestationVerification => {
-                    Err(opensecret::Error::AttestationVerificationFailed(
+                    Err(maple_sdk::Error::AttestationVerificationFailed(
                         "private attestation detail".to_string(),
                     ))
                 }

--- a/apps/maple-agent/crates/maple-agent/src/agent/developer_tools.rs
+++ b/apps/maple-agent/crates/maple-agent/src/agent/developer_tools.rs
@@ -2557,7 +2557,7 @@ mod tests {
     use goose::providers::base::{ProviderUsage, Usage};
     use goose::session::SessionManager;
     use goose::session::SessionType;
-    use opensecret::{
+    use maple_sdk::{
         WebExtractPage, WebExtractRequest, WebExtractResponse, WebSearchRequest, WebSearchResponse,
         WebSearchResult,
     };
@@ -2594,7 +2594,7 @@ mod tests {
             self: Arc<Self>,
             _request: WebSearchRequest,
             _cancel_token: CancellationToken,
-        ) -> opensecret::Result<WebSearchResponse> {
+        ) -> maple_sdk::Result<WebSearchResponse> {
             Ok(WebSearchResponse {
                 trace_id: None,
                 results: vec![WebSearchResult {
@@ -2611,7 +2611,7 @@ mod tests {
             self: Arc<Self>,
             request: WebExtractRequest,
             _cancel_token: CancellationToken,
-        ) -> opensecret::Result<WebExtractResponse> {
+        ) -> maple_sdk::Result<WebExtractResponse> {
             Ok(WebExtractResponse {
                 trace_id: None,
                 pages: vec![WebExtractPage {

--- a/apps/maple-agent/crates/maple-agent/src/agent/provider.rs
+++ b/apps/maple-agent/crates/maple-agent/src/agent/provider.rs
@@ -14,7 +14,7 @@ use goose_providers::retry::{
     DEFAULT_BACKOFF_MULTIPLIER, DEFAULT_INITIAL_RETRY_INTERVAL_MS, DEFAULT_MAX_RETRY_INTERVAL_MS,
     RetryConfig, should_retry,
 };
-use opensecret::{InferenceRequest, InferenceResponse, OpenSecretClient, OpenSecretResponseBody};
+use maple_sdk::{InferenceRequest, InferenceResponse, OpenSecretClient, OpenSecretResponseBody};
 use rmcp::model::Tool;
 use serde_json::{Value, json};
 use std::cell::Cell;
@@ -134,7 +134,7 @@ pub(crate) trait MapleInferenceTransport: Send + Sync {
         self: Arc<Self>,
         request: InferenceRequest,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<InferenceResponse>;
+    ) -> maple_sdk::Result<InferenceResponse>;
 }
 
 /// A direct SDK client is also a valid transport. Maple's account-scoped auth
@@ -146,11 +146,11 @@ impl MapleInferenceTransport for OpenSecretClient {
         self: Arc<Self>,
         request: InferenceRequest,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<InferenceResponse> {
+    ) -> maple_sdk::Result<InferenceResponse> {
         tokio::select! {
             biased;
             _ = cancel_token.cancelled() => {
-                Err(opensecret::Error::Other("Inference request was cancelled".to_string()))
+                Err(maple_sdk::Error::Other("Inference request was cancelled".to_string()))
             }
             response = OpenSecretClient::send_inference_request(&self, request) => response,
         }
@@ -899,7 +899,7 @@ fn is_context_length_exceeded_message(text: &str) -> bool {
     mentions_prompt_input_tokens && mentions_limit && mentions_overflow
 }
 
-fn map_opensecret_error(error: opensecret::Error) -> ProviderError {
+fn map_opensecret_error(error: maple_sdk::Error) -> ProviderError {
     log::warn!(
         "OpenSecret inference transport failed ({})",
         opensecret_error_category(&error)
@@ -907,50 +907,50 @@ fn map_opensecret_error(error: opensecret::Error) -> ProviderError {
     map_opensecret_error_kind(error)
 }
 
-fn map_opensecret_error_kind(error: opensecret::Error) -> ProviderError {
+fn map_opensecret_error_kind(error: maple_sdk::Error) -> ProviderError {
     match error {
-        opensecret::Error::Authentication(_) | opensecret::Error::Api { status: 401, .. } => {
+        maple_sdk::Error::Authentication(_) | maple_sdk::Error::Api { status: 401, .. } => {
             ProviderError::Authentication(AUTHENTICATION_ERROR_MESSAGE.to_string())
         }
-        opensecret::Error::Api {
+        maple_sdk::Error::Api {
             status: 402,
             message: _,
         } => ProviderError::CreditsExhausted {
             details: "Maple credits are exhausted".to_string(),
             top_up_url: None,
         },
-        opensecret::Error::Api {
+        maple_sdk::Error::Api {
             status: 413,
             message: _,
         } => ProviderError::ContextLengthExceeded(
             "The Maple request exceeds the model's context window".to_string(),
         ),
-        opensecret::Error::Api {
+        maple_sdk::Error::Api {
             status: 400,
             message,
         } if is_context_length_exceeded_message(&message) => ProviderError::ContextLengthExceeded(
             "The Maple request exceeds the model's context window".to_string(),
         ),
-        opensecret::Error::Api {
+        maple_sdk::Error::Api {
             status: 429,
             message: _,
         } => ProviderError::RateLimitExceeded {
             details: "Maple rate limit exceeded".to_string(),
             retry_delay: None,
         },
-        opensecret::Error::Api { status, message: _ } if (500..=599).contains(&status) => {
+        maple_sdk::Error::Api { status, message: _ } if (500..=599).contains(&status) => {
             ProviderError::ServerError(format!("Maple's server returned status {status}"))
         }
-        opensecret::Error::Api {
+        maple_sdk::Error::Api {
             status: 404,
             message: _,
         } => ProviderError::EndpointNotFound(
             "The Maple inference endpoint was not found".to_string(),
         ),
-        opensecret::Error::Api { status, message: _ } => {
+        maple_sdk::Error::Api { status, message: _ } => {
             ProviderError::RequestFailed(format!("Maple request failed with status {status}"))
         }
-        opensecret::Error::Http(error) => {
+        maple_sdk::Error::Http(error) => {
             if error.is_timeout() {
                 ProviderError::NetworkError("The Maple request timed out".to_string())
             } else if error.is_connect() {
@@ -959,30 +959,30 @@ fn map_opensecret_error_kind(error: opensecret::Error) -> ProviderError {
                 ProviderError::NetworkError("The Maple network request failed".to_string())
             }
         }
-        opensecret::Error::AttestationVerificationFailed(_) => {
+        maple_sdk::Error::AttestationVerificationFailed(_) => {
             ProviderError::ExecutionError(ATTESTATION_VERIFICATION_ERROR_MESSAGE.to_string())
         }
-        opensecret::Error::Session(_)
-        | opensecret::Error::KeyExchange(_)
-        | opensecret::Error::Encryption(_)
-        | opensecret::Error::Decryption(_)
-        | opensecret::Error::InvalidResponse(_)
-        | opensecret::Error::Crypto(_)
-        | opensecret::Error::Cbor(_)
-        | opensecret::Error::Io(_)
-        | opensecret::Error::Utf8(_)
-        | opensecret::Error::Base64Decode(_) => {
+        maple_sdk::Error::Session(_)
+        | maple_sdk::Error::KeyExchange(_)
+        | maple_sdk::Error::Encryption(_)
+        | maple_sdk::Error::Decryption(_)
+        | maple_sdk::Error::InvalidResponse(_)
+        | maple_sdk::Error::Crypto(_)
+        | maple_sdk::Error::Cbor(_)
+        | maple_sdk::Error::Io(_)
+        | maple_sdk::Error::Utf8(_)
+        | maple_sdk::Error::Base64Decode(_) => {
             ProviderError::ExecutionError(SECURE_CONNECTION_ERROR_MESSAGE.to_string())
         }
-        opensecret::Error::Serialization(_)
-        | opensecret::Error::Configuration(_)
-        | opensecret::Error::Other(_) => ProviderError::ExecutionError(
+        maple_sdk::Error::Serialization(_)
+        | maple_sdk::Error::Configuration(_)
+        | maple_sdk::Error::Other(_) => ProviderError::ExecutionError(
             "Maple could not prepare the encrypted request".to_string(),
         ),
     }
 }
 
-fn map_response_stream_error(error: opensecret::Error) -> std::io::Error {
+fn map_response_stream_error(error: maple_sdk::Error) -> std::io::Error {
     log::warn!(
         "Failed to read encrypted Maple response stream ({})",
         opensecret_error_category(&error)
@@ -1006,25 +1006,25 @@ fn secure_connection_stream_error(error: &anyhow::Error) -> Option<ProviderError
     })
 }
 
-pub(crate) fn opensecret_error_category(error: &opensecret::Error) -> &'static str {
+pub(crate) fn opensecret_error_category(error: &maple_sdk::Error) -> &'static str {
     match error {
-        opensecret::Error::Http(_) => "http",
-        opensecret::Error::Serialization(_) => "serialization",
-        opensecret::Error::Cbor(_) => "cbor",
-        opensecret::Error::Crypto(_) => "crypto",
-        opensecret::Error::AttestationVerificationFailed(_) => "attestation",
-        opensecret::Error::Session(_) => "session",
-        opensecret::Error::KeyExchange(_) => "key_exchange",
-        opensecret::Error::Encryption(_) => "encryption",
-        opensecret::Error::Decryption(_) => "decryption",
-        opensecret::Error::Authentication(_) => "authentication",
-        opensecret::Error::InvalidResponse(_) => "invalid_response",
-        opensecret::Error::Api { .. } => "api",
-        opensecret::Error::Configuration(_) => "configuration",
-        opensecret::Error::Io(_) => "io",
-        opensecret::Error::Utf8(_) => "utf8",
-        opensecret::Error::Base64Decode(_) => "base64",
-        opensecret::Error::Other(_) => "other",
+        maple_sdk::Error::Http(_) => "http",
+        maple_sdk::Error::Serialization(_) => "serialization",
+        maple_sdk::Error::Cbor(_) => "cbor",
+        maple_sdk::Error::Crypto(_) => "crypto",
+        maple_sdk::Error::AttestationVerificationFailed(_) => "attestation",
+        maple_sdk::Error::Session(_) => "session",
+        maple_sdk::Error::KeyExchange(_) => "key_exchange",
+        maple_sdk::Error::Encryption(_) => "encryption",
+        maple_sdk::Error::Decryption(_) => "decryption",
+        maple_sdk::Error::Authentication(_) => "authentication",
+        maple_sdk::Error::InvalidResponse(_) => "invalid_response",
+        maple_sdk::Error::Api { .. } => "api",
+        maple_sdk::Error::Configuration(_) => "configuration",
+        maple_sdk::Error::Io(_) => "io",
+        maple_sdk::Error::Utf8(_) => "utf8",
+        maple_sdk::Error::Base64Decode(_) => "base64",
+        maple_sdk::Error::Other(_) => "other",
     }
 }
 
@@ -1049,7 +1049,7 @@ mod tests {
 
     struct FakeTransport {
         requests: Mutex<Vec<CapturedRequest>>,
-        responses: Mutex<VecDeque<opensecret::Result<InferenceResponse>>>,
+        responses: Mutex<VecDeque<maple_sdk::Result<InferenceResponse>>>,
         request_notify: Notify,
     }
 
@@ -1061,9 +1061,9 @@ mod tests {
             self: Arc<Self>,
             _request: InferenceRequest,
             cancel_token: CancellationToken,
-        ) -> opensecret::Result<InferenceResponse> {
+        ) -> maple_sdk::Result<InferenceResponse> {
             cancel_token.cancelled().await;
-            Err(opensecret::Error::Other(
+            Err(maple_sdk::Error::Other(
                 "Pending transport was cancelled".to_string(),
             ))
         }
@@ -1082,7 +1082,7 @@ mod tests {
             Self::with_results(responses.into_iter().map(Ok).collect())
         }
 
-        fn with_results(responses: Vec<opensecret::Result<InferenceResponse>>) -> Self {
+        fn with_results(responses: Vec<maple_sdk::Result<InferenceResponse>>) -> Self {
             Self {
                 requests: Mutex::new(Vec::new()),
                 responses: Mutex::new(responses.into()),
@@ -1115,7 +1115,7 @@ mod tests {
             self: Arc<Self>,
             request: InferenceRequest,
             _cancel_token: CancellationToken,
-        ) -> opensecret::Result<InferenceResponse> {
+        ) -> maple_sdk::Result<InferenceResponse> {
             let (parts, body) = request.into_parts();
             let captured = CapturedRequest {
                 method: parts.method.to_string(),
@@ -1140,7 +1140,7 @@ mod tests {
 
     fn response_with_items(
         status: u16,
-        items: Vec<opensecret::Result<Vec<u8>>>,
+        items: Vec<maple_sdk::Result<Vec<u8>>>,
         retry_after: Option<&str>,
     ) -> InferenceResponse {
         let body: OpenSecretResponseBody = Box::pin(futures_util::stream::iter(
@@ -1881,7 +1881,7 @@ mod tests {
             200,
             vec![
                 Ok(first_chunk),
-                Err(opensecret::Error::InvalidResponse(
+                Err(maple_sdk::Error::InvalidResponse(
                     "private post-item stream failure".to_string(),
                 )),
             ],
@@ -1941,7 +1941,7 @@ mod tests {
             200,
             vec![
                 Ok(usage_chunk),
-                Err(opensecret::Error::InvalidResponse(
+                Err(maple_sdk::Error::InvalidResponse(
                     "private post-usage stream failure".to_string(),
                 )),
             ],
@@ -2099,7 +2099,7 @@ mod tests {
             200,
             vec![
                 Ok(complete_tool_call_event()),
-                Err(opensecret::Error::InvalidResponse(
+                Err(maple_sdk::Error::InvalidResponse(
                     "private completed tool stream failure".to_string(),
                 )),
             ],
@@ -2255,7 +2255,7 @@ mod tests {
         let retry_config = fast_retry_config(3);
         let errors = [
             map_http_error(http::StatusCode::FORBIDDEN, None),
-            map_opensecret_error(opensecret::Error::Api {
+            map_opensecret_error(maple_sdk::Error::Api {
                 status: 403,
                 message: "private plan detail".to_string(),
             }),
@@ -2323,18 +2323,18 @@ mod tests {
     fn secure_connection_sdk_errors_are_fixed_and_non_transient() {
         let retry_config = fast_retry_config(3);
         let errors = vec![
-            opensecret::Error::Session("private session detail".to_string()),
-            opensecret::Error::KeyExchange("private key detail".to_string()),
-            opensecret::Error::Encryption("private encryption detail".to_string()),
-            opensecret::Error::Decryption("private decryption detail".to_string()),
-            opensecret::Error::InvalidResponse("private response detail".to_string()),
-            opensecret::Error::Crypto("private crypto detail".to_string()),
-            opensecret::Error::Cbor("private cbor detail".to_string()),
-            opensecret::Error::Io(std::io::Error::other("private io detail")),
-            opensecret::Error::Utf8(
+            maple_sdk::Error::Session("private session detail".to_string()),
+            maple_sdk::Error::KeyExchange("private key detail".to_string()),
+            maple_sdk::Error::Encryption("private encryption detail".to_string()),
+            maple_sdk::Error::Decryption("private decryption detail".to_string()),
+            maple_sdk::Error::InvalidResponse("private response detail".to_string()),
+            maple_sdk::Error::Crypto("private crypto detail".to_string()),
+            maple_sdk::Error::Cbor("private cbor detail".to_string()),
+            maple_sdk::Error::Io(std::io::Error::other("private io detail")),
+            maple_sdk::Error::Utf8(
                 String::from_utf8(vec![0xff]).expect_err("invalid UTF-8 fixture"),
             ),
-            opensecret::Error::Base64Decode(base64::DecodeError::InvalidByte(0, b'%')),
+            maple_sdk::Error::Base64Decode(base64::DecodeError::InvalidByte(0, b'%')),
         ];
 
         for error in errors {
@@ -2413,7 +2413,7 @@ mod tests {
     #[tokio::test]
     async fn terminal_attestation_failure_is_one_send_and_is_latched_for_the_run() {
         let transport = Arc::new(FakeTransport::with_results(vec![
-            Err(opensecret::Error::AttestationVerificationFailed(
+            Err(maple_sdk::Error::AttestationVerificationFailed(
                 "private attestation detail".to_string(),
             )),
             Ok(fragmented_success_response()),
@@ -2450,7 +2450,7 @@ mod tests {
     #[tokio::test]
     async fn terminal_secure_connection_failure_is_one_send_and_is_latched_for_the_run() {
         let transport = Arc::new(FakeTransport::with_results(vec![
-            Err(opensecret::Error::Session(
+            Err(maple_sdk::Error::Session(
                 "private exhausted session detail".to_string(),
             )),
             Ok(fragmented_success_response()),
@@ -2488,7 +2488,7 @@ mod tests {
     async fn terminal_secure_stream_failure_is_one_send_and_is_latched_for_the_run() {
         let failed = response_with_items(
             200,
-            vec![Err(opensecret::Error::Decryption(
+            vec![Err(maple_sdk::Error::Decryption(
                 "private lazy decryption detail".to_string(),
             ))],
             None,
@@ -2542,7 +2542,7 @@ mod tests {
             assert!(!error.to_string().contains(PRIVATE_DETAIL));
             assert!(!format!("{error:?}").contains(PRIVATE_DETAIL));
 
-            let sdk_error = map_opensecret_error(opensecret::Error::Api {
+            let sdk_error = map_opensecret_error(maple_sdk::Error::Api {
                 status,
                 message: PRIVATE_DETAIL.to_string(),
             });
@@ -2553,7 +2553,7 @@ mod tests {
 
     #[test]
     fn sdk_context_error_is_classified_without_exposing_provider_message() {
-        let error = map_opensecret_error(opensecret::Error::Api {
+        let error = map_opensecret_error(maple_sdk::Error::Api {
             status: 400,
             message: "maximum context length exceeded; private token counts".to_string(),
         });

--- a/apps/maple-agent/crates/maple-agent/src/agent/web_tools.rs
+++ b/apps/maple-agent/crates/maple-agent/src/agent/web_tools.rs
@@ -1,5 +1,5 @@
 use crate::maple_api::MapleWebTransport;
-use opensecret::{
+use maple_sdk::{
     WebExtractRequest, WebSearchFilters, WebSearchLens, WebSearchRequest, WebSearchResult,
     WebSearchWorkflow,
 };
@@ -251,7 +251,7 @@ pub(crate) async fn execute_web_search(
         return Err("Web search was cancelled".to_string());
     }
 
-    let opensecret::WebSearchResponse {
+    let maple_sdk::WebSearchResponse {
         trace_id,
         mut results,
     } = response;
@@ -303,7 +303,7 @@ pub(crate) async fn execute_open_url(
         return Err("URL extraction was cancelled".to_string());
     }
 
-    let opensecret::WebExtractResponse { trace_id, pages } = response;
+    let maple_sdk::WebExtractResponse { trace_id, pages } = response;
     let page = pages
         .into_iter()
         .find(|page| normalize_public_https_url(&page.url).is_ok_and(|page_url| page_url == url))
@@ -586,7 +586,7 @@ fn bound_web_tool_error(error: String, final_output_limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opensecret::{WebExtractPage, WebExtractResponse, WebSearchResponse, WebSearchResult};
+    use maple_sdk::{WebExtractPage, WebExtractResponse, WebSearchResponse, WebSearchResult};
     use std::sync::Mutex as StdMutex;
 
     struct MockTransport {
@@ -603,11 +603,11 @@ mod tests {
             self: Arc<Self>,
             request: WebSearchRequest,
             cancel_token: CancellationToken,
-        ) -> opensecret::Result<WebSearchResponse> {
+        ) -> maple_sdk::Result<WebSearchResponse> {
             self.searches.lock().unwrap().push(request);
             if self.wait_for_cancellation {
                 cancel_token.cancelled().await;
-                return Err(opensecret::Error::Other("cancelled".to_string()));
+                return Err(maple_sdk::Error::Other("cancelled".to_string()));
             }
             Ok(self.search_response.clone())
         }
@@ -616,11 +616,11 @@ mod tests {
             self: Arc<Self>,
             request: WebExtractRequest,
             cancel_token: CancellationToken,
-        ) -> opensecret::Result<WebExtractResponse> {
+        ) -> maple_sdk::Result<WebExtractResponse> {
             self.extracts.lock().unwrap().push(request);
             if self.wait_for_cancellation {
                 cancel_token.cancelled().await;
-                return Err(opensecret::Error::Other("cancelled".to_string()));
+                return Err(maple_sdk::Error::Other("cancelled".to_string()));
             }
             Ok(self.extract_response.clone())
         }

--- a/apps/maple-agent/crates/maple-agent/src/maple_api.rs
+++ b/apps/maple-agent/crates/maple-agent/src/maple_api.rs
@@ -1,5 +1,5 @@
 use crate::open_secret_config::configured_pcr0_environment;
-use opensecret::{
+use maple_sdk::{
     InferenceRequest, InferenceResponse, OpenSecretClient, WebExtractRequest, WebExtractResponse,
     WebSearchRequest, WebSearchResponse,
 };
@@ -60,20 +60,20 @@ impl MapleLoginMethod {
     }
 }
 
-impl From<opensecret::LoginMethod> for MapleLoginMethod {
-    fn from(method: opensecret::LoginMethod) -> Self {
+impl From<maple_sdk::LoginMethod> for MapleLoginMethod {
+    fn from(method: maple_sdk::LoginMethod) -> Self {
         match method {
-            opensecret::LoginMethod::Email => Self::Email,
-            opensecret::LoginMethod::Github => Self::Github,
-            opensecret::LoginMethod::Google => Self::Google,
-            opensecret::LoginMethod::Apple => Self::Apple,
-            opensecret::LoginMethod::Guest => Self::Guest,
+            maple_sdk::LoginMethod::Email => Self::Email,
+            maple_sdk::LoginMethod::Github => Self::Github,
+            maple_sdk::LoginMethod::Google => Self::Google,
+            maple_sdk::LoginMethod::Apple => Self::Apple,
+            maple_sdk::LoginMethod::Guest => Self::Guest,
         }
     }
 }
 
-impl From<opensecret::AppUser> for MapleAccount {
-    fn from(user: opensecret::AppUser) -> Self {
+impl From<maple_sdk::AppUser> for MapleAccount {
+    fn from(user: maple_sdk::AppUser) -> Self {
         Self {
             user_id: user.id.to_string(),
             email: user.email,
@@ -146,17 +146,17 @@ pub fn new_confirmation_secret() -> (String, String) {
     (plaintext, hashed)
 }
 
-fn map_account_error(error: opensecret::Error) -> MapleAccountError {
+fn map_account_error(error: maple_sdk::Error) -> MapleAccountError {
     log::warn!(
         "OpenSecret SDK account operation failed ({})",
         crate::agent::provider::opensecret_error_category(&error)
     );
     match error {
-        opensecret::Error::Authentication(_)
-        | opensecret::Error::Api {
+        maple_sdk::Error::Authentication(_)
+        | maple_sdk::Error::Api {
             status: 401 | 403, ..
         } => MapleAccountError::Unauthorized,
-        opensecret::Error::Api { status, .. } => MapleAccountError::Status(status),
+        maple_sdk::Error::Api { status, .. } => MapleAccountError::Status(status),
         _ => MapleAccountError::Other("Maple API request failed".to_string()),
     }
 }
@@ -521,7 +521,7 @@ impl MapleApiSession {
         Ok(response.data.into_iter().map(|model| model.id).collect())
     }
 
-    pub(crate) async fn model_catalog(&self) -> Result<opensecret::ModelCatalogResponse, String> {
+    pub(crate) async fn model_catalog(&self) -> Result<maple_sdk::ModelCatalogResponse, String> {
         let snapshot = self.client_snapshot().await?;
         let response = snapshot.client.get_model_catalog().await;
         self.record_refresh(&snapshot).await?;
@@ -581,11 +581,11 @@ impl MapleApiSession {
         self: Arc<Self>,
         request: InferenceRequest,
         cancel_token: CancellationToken,
-    ) -> Result<InferenceResponse, opensecret::Error> {
+    ) -> Result<InferenceResponse, maple_sdk::Error> {
         let snapshot = self
             .client_snapshot()
             .await
-            .map_err(opensecret::Error::Authentication)?;
+            .map_err(maple_sdk::Error::Authentication)?;
         let operation_cancel = cancel_token.child_token();
         let _cancel_on_drop = CancelOperationOnDrop(operation_cancel.clone());
         let session = Arc::clone(&self);
@@ -593,7 +593,7 @@ impl MapleApiSession {
             let response = tokio::select! {
                 biased;
                 _ = operation_cancel.cancelled() => {
-                    Err(opensecret::Error::Other("Inference request was cancelled".to_string()))
+                    Err(maple_sdk::Error::Other("Inference request was cancelled".to_string()))
                 }
                 response = snapshot.client.send_inference_request(request) => response,
             };
@@ -609,11 +609,11 @@ impl MapleApiSession {
         self: Arc<Self>,
         request: WebSearchRequest,
         cancel_token: CancellationToken,
-    ) -> Result<WebSearchResponse, opensecret::Error> {
+    ) -> Result<WebSearchResponse, maple_sdk::Error> {
         let snapshot = self
             .client_snapshot()
             .await
-            .map_err(opensecret::Error::Authentication)?;
+            .map_err(maple_sdk::Error::Authentication)?;
         let operation_cancel = cancel_token.child_token();
         let _cancel_on_drop = CancelOperationOnDrop(operation_cancel.clone());
         let session = Arc::clone(&self);
@@ -621,7 +621,7 @@ impl MapleApiSession {
             let response = tokio::select! {
                 biased;
                 _ = operation_cancel.cancelled() => {
-                    Err(opensecret::Error::Other("Web search was cancelled".to_string()))
+                    Err(maple_sdk::Error::Other("Web search was cancelled".to_string()))
                 }
                 response = snapshot.client.web_search(request) => response,
             };
@@ -637,11 +637,11 @@ impl MapleApiSession {
         self: Arc<Self>,
         request: WebExtractRequest,
         cancel_token: CancellationToken,
-    ) -> Result<WebExtractResponse, opensecret::Error> {
+    ) -> Result<WebExtractResponse, maple_sdk::Error> {
         let snapshot = self
             .client_snapshot()
             .await
-            .map_err(opensecret::Error::Authentication)?;
+            .map_err(maple_sdk::Error::Authentication)?;
         let operation_cancel = cancel_token.child_token();
         let _cancel_on_drop = CancelOperationOnDrop(operation_cancel.clone());
         let session = Arc::clone(&self);
@@ -649,7 +649,7 @@ impl MapleApiSession {
             let response = tokio::select! {
                 biased;
                 _ = operation_cancel.cancelled() => {
-                    Err(opensecret::Error::Other("Web extraction was cancelled".to_string()))
+                    Err(maple_sdk::Error::Other("Web extraction was cancelled".to_string()))
                 }
                 response = snapshot.client.web_extract(request) => response,
             };
@@ -688,9 +688,9 @@ pub(crate) fn test_maple_api_session(user_id: &str) -> Arc<MapleApiSession> {
     )
 }
 
-fn map_operation_join_error(error: tokio::task::JoinError) -> opensecret::Error {
+fn map_operation_join_error(error: tokio::task::JoinError) -> maple_sdk::Error {
     log::warn!("Maple API operation task failed: {error}");
-    opensecret::Error::Other("Maple API operation failed".to_string())
+    maple_sdk::Error::Other("Maple API operation failed".to_string())
 }
 
 #[async_trait::async_trait]
@@ -699,13 +699,13 @@ pub(crate) trait MapleWebTransport: Send + Sync {
         self: Arc<Self>,
         request: WebSearchRequest,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<WebSearchResponse>;
+    ) -> maple_sdk::Result<WebSearchResponse>;
 
     async fn web_extract(
         self: Arc<Self>,
         request: WebExtractRequest,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<WebExtractResponse>;
+    ) -> maple_sdk::Result<WebExtractResponse>;
 }
 
 #[async_trait::async_trait]
@@ -714,7 +714,7 @@ impl MapleWebTransport for MapleApiSession {
         self: Arc<Self>,
         request: WebSearchRequest,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<WebSearchResponse> {
+    ) -> maple_sdk::Result<WebSearchResponse> {
         MapleApiSession::web_search(self, request, cancel_token).await
     }
 
@@ -722,7 +722,7 @@ impl MapleWebTransport for MapleApiSession {
         self: Arc<Self>,
         request: WebExtractRequest,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<WebExtractResponse> {
+    ) -> maple_sdk::Result<WebExtractResponse> {
         MapleApiSession::web_extract(self, request, cancel_token).await
     }
 }
@@ -733,7 +733,7 @@ impl crate::agent::provider::MapleInferenceTransport for MapleApiSession {
         self: Arc<Self>,
         request: InferenceRequest,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<InferenceResponse> {
+    ) -> maple_sdk::Result<InferenceResponse> {
         MapleApiSession::send_inference_request(self, request, cancel_token).await
     }
 }
@@ -785,14 +785,14 @@ pub fn is_auth_rejection(message: &str) -> bool {
     message == AUTH_REJECTED_MESSAGE || message == AUTH_WRONG_ACCOUNT_MESSAGE
 }
 
-fn map_sdk_error(error: opensecret::Error) -> String {
+fn map_sdk_error(error: maple_sdk::Error) -> String {
     log::warn!(
         "OpenSecret SDK authentication operation failed ({})",
         crate::agent::provider::opensecret_error_category(&error)
     );
     match error {
-        opensecret::Error::Authentication(_)
-        | opensecret::Error::Api {
+        maple_sdk::Error::Authentication(_)
+        | maple_sdk::Error::Api {
             status: 401 | 403, ..
         } => AUTH_REJECTED_MESSAGE.to_string(),
         _ => "Maple API authentication failed".to_string(),
@@ -1046,15 +1046,15 @@ mod tests {
 
     #[test]
     fn only_refused_credentials_count_as_rejection() {
-        let rejected = map_sdk_error(opensecret::Error::Authentication("bad token".into()));
+        let rejected = map_sdk_error(maple_sdk::Error::Authentication("bad token".into()));
         assert!(is_auth_rejection(&rejected));
-        let forbidden = map_sdk_error(opensecret::Error::Api {
+        let forbidden = map_sdk_error(maple_sdk::Error::Api {
             status: 401,
             message: "expired".into(),
         });
         assert!(is_auth_rejection(&forbidden));
         assert!(is_auth_rejection(AUTH_WRONG_ACCOUNT_MESSAGE));
-        let outage = map_sdk_error(opensecret::Error::Api {
+        let outage = map_sdk_error(maple_sdk::Error::Api {
             status: 503,
             message: "down".into(),
         });
@@ -1073,7 +1073,7 @@ mod tests {
     use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
     use ciborium::value::Value as CborValue;
     use goose_providers::{base::Provider, conversation::message::Message, model::ModelConfig};
-    use opensecret::types::KeyExchangeRequest;
+    use maple_sdk::types::KeyExchangeRequest;
     use std::sync::Mutex as StdMutex;
     use tokio::sync::Notify;
 
@@ -1133,7 +1133,7 @@ mod tests {
 
     #[derive(Clone)]
     struct RefreshThenStallState {
-        key_pair: Arc<opensecret::crypto::KeyPair>,
+        key_pair: Arc<maple_sdk::crypto::KeyPair>,
         session_key: [u8; 32],
         session_id: String,
         retry_started: Arc<Notify>,
@@ -1187,13 +1187,13 @@ mod tests {
         Json(request): Json<KeyExchangeRequest>,
     ) -> Json<serde_json::Value> {
         let client_public_bytes = BASE64.decode(request.client_public_key).unwrap();
-        let client_public_key = opensecret::crypto::PublicKey::from(
+        let client_public_key = maple_sdk::crypto::PublicKey::from(
             <[u8; 32]>::try_from(client_public_bytes.as_slice()).unwrap(),
         );
         let shared_secret =
-            opensecret::crypto::derive_shared_secret(&state.key_pair.secret, &client_public_key);
+            maple_sdk::crypto::derive_shared_secret(&state.key_pair.secret, &client_public_key);
         let encrypted_session_key = BASE64.encode(
-            opensecret::crypto::encrypt_data(shared_secret.as_bytes(), &state.session_key).unwrap(),
+            maple_sdk::crypto::encrypt_data(shared_secret.as_bytes(), &state.session_key).unwrap(),
         );
         Json(serde_json::json!({
             "encrypted_session_key": encrypted_session_key,
@@ -1209,7 +1209,7 @@ mod tests {
             "refresh_token": "fresh_refresh",
         }))
         .unwrap();
-        let encrypted = opensecret::crypto::encrypt_data(&state.session_key, &plaintext).unwrap();
+        let encrypted = maple_sdk::crypto::encrypt_data(&state.session_key, &plaintext).unwrap();
         Json(serde_json::json!({ "encrypted": BASE64.encode(encrypted) }))
     }
 
@@ -1233,7 +1233,7 @@ mod tests {
     }
 
     async fn refresh_then_stall_fixture() -> RefreshThenStallFixture {
-        let key_pair = Arc::new(opensecret::crypto::generate_key_pair());
+        let key_pair = Arc::new(maple_sdk::crypto::generate_key_pair());
         let retry_started = Arc::new(Notify::new());
         let state = RefreshThenStallState {
             key_pair,
@@ -1459,7 +1459,7 @@ mod tests {
             .web_search(WebSearchRequest::new("maple privacy"), search_cancel)
             .await;
         assert!(
-            matches!(search, Err(opensecret::Error::Other(message)) if message.contains("cancelled"))
+            matches!(search, Err(maple_sdk::Error::Other(message)) if message.contains("cancelled"))
         );
 
         let extract_cancel = CancellationToken::new();
@@ -1471,7 +1471,7 @@ mod tests {
             )
             .await;
         assert!(
-            matches!(extract, Err(opensecret::Error::Other(message)) if message.contains("cancelled"))
+            matches!(extract, Err(maple_sdk::Error::Other(message)) if message.contains("cancelled"))
         );
 
         let after = session.auth_snapshot().await.unwrap();

--- a/apps/maple-research/AGENTS.md
+++ b/apps/maple-research/AGENTS.md
@@ -38,7 +38,7 @@ Maple is a React/Vite application packaged with Tauri for desktop and mobile.
 OpenSecret is its required backend. Keep these runtime paths distinct:
 
 - Research chat: React -> OpenAI JavaScript client ->
-  `@opensecret/react` encrypted custom fetch -> OpenSecret Responses and
+  `@mapleai/sdk` encrypted custom fetch -> OpenSecret Responses and
   Conversations APIs.
 - Desktop Agent Mode: React -> Maple-owned Tauri commands/events ->
   `MapleAgentService` -> embedded pinned Goose -> `MapleProvider` -> Rust

--- a/apps/maple-research/docs/conversations-api-implementation.md
+++ b/apps/maple-research/docs/conversations-api-implementation.md
@@ -187,7 +187,7 @@ The v5+ SDK includes full support for:
 Create client with OpenSecret's custom fetch from the SDK:
 
 ```typescript
-import { createCustomFetch } from "@opensecret/react";
+import { createCustomFetch } from "@mapleai/sdk";
 import OpenAI from "openai";
 
 // Get API URL from environment
@@ -205,7 +205,7 @@ const openai = new OpenAI({
 });
 ```
 
-The custom fetch from `@opensecret/react` handles:
+The custom fetch from `@mapleai/sdk` handles:
 - JWT token injection from localStorage
 - Automatic token refresh on 401
 - Session key encryption/decryption for E2E encryption

--- a/apps/maple-research/frontend/bun.lock
+++ b/apps/maple-research/frontend/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "maple",
       "dependencies": {
-        "@opensecret/react": "file:../../../sdk",
+        "@mapleai/sdk": "file:../../../sdk",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -234,6 +234,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@mapleai/sdk": ["@mapleai/sdk@file:../../../sdk", { "dependencies": { "@peculiar/x509": "1.14.3", "@stablelib/base64": "2.0.1", "@stablelib/chacha20poly1305": "2.0.1", "@stablelib/random": "2.0.1", "cbor2": "1.12.0", "openai": "5.23.2", "tweetnacl": "1.0.3", "zod": "3.25.76" }, "devDependencies": { "@eslint/js": "9.39.5", "@noble/curves": "1.9.7", "@noble/hashes": "1.8.0", "@types/bun": "1.1.13", "@types/react": "19.2.18", "@vitejs/plugin-react": "4.7.0", "ajv": "8.20.0", "eslint": "9.39.5", "eslint-plugin-react-hooks": "5.2.0", "globals": "15.15.0", "prettier": "3.9.6", "typescript": "5.6.3", "typescript-eslint": "8.66.0", "vite": "6.4.3", "vite-plugin-dts": "4.5.4" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }],
+
     "@microsoft/api-extractor": ["@microsoft/api-extractor@7.58.12", "", { "dependencies": { "@microsoft/api-extractor-model": "7.33.10", "@microsoft/tsdoc": "~0.16.0", "@microsoft/tsdoc-config": "~0.18.1", "@rushstack/node-core-library": "5.23.3", "@rushstack/rig-package": "0.7.3", "@rushstack/terminal": "0.24.2", "@rushstack/ts-command-line": "5.3.12", "diff": "~8.0.2", "minimatch": "10.2.3", "resolve": "~1.22.1", "semver": "~7.7.4", "source-map": "~0.6.1", "typescript": "5.9.3" }, "bin": { "api-extractor": "bin/api-extractor" } }, "sha512-VNpgC/1LaroLbn+UKmwDYspq+9r3EHyj4vJ3qUy/g8vB0rKt+1Wgs7WFj/JGpgxhG8SNyXs1XwYwe7nqkk8IDg=="],
 
     "@microsoft/api-extractor-model": ["@microsoft/api-extractor-model@7.33.10", "", { "dependencies": { "@microsoft/tsdoc": "~0.16.0", "@microsoft/tsdoc-config": "~0.18.1", "@rushstack/node-core-library": "5.23.3" } }, "sha512-uPUK17xGxeQ3av6TN7awp+dTTSTvx8fZC0XFL1gyt7hFapYuxND3XLXH8vkmI7UjfW92oogzFAFqHSifmJROaw=="],
@@ -251,8 +253,6 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
-
-    "@opensecret/react": ["@opensecret/react@file:../../../sdk", { "dependencies": { "@peculiar/x509": "1.14.3", "@stablelib/base64": "2.0.1", "@stablelib/chacha20poly1305": "2.0.1", "@stablelib/random": "2.0.1", "cbor2": "1.12.0", "tweetnacl": "1.0.3", "zod": "3.25.76" }, "devDependencies": { "@eslint/js": "9.39.5", "@noble/curves": "1.9.7", "@noble/hashes": "1.8.0", "@types/bun": "1.1.13", "@types/react": "19.2.18", "@vitejs/plugin-react": "4.7.0", "ajv": "8.20.0", "eslint": "9.39.5", "eslint-plugin-react-hooks": "5.2.0", "globals": "15.15.0", "openai": "5.23.2", "prettier": "3.9.6", "typescript": "5.6.3", "typescript-eslint": "8.66.0", "vite": "6.4.3", "vite-plugin-dts": "4.5.4" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }],
 
     "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA=="],
 
@@ -1324,29 +1324,29 @@
 
     "@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
+    "@mapleai/sdk/@eslint/js": ["@eslint/js@9.39.5", "", {}, "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A=="],
+
+    "@mapleai/sdk/@types/bun": ["@types/bun@1.1.13", "", { "dependencies": { "bun-types": "1.1.34" } }, "sha512-KmQxSBgVWCl6RSuerlLGZlIWfdxkKqat0nxN61+qu4y1KDn0Ll3j7v1Pl8GnaL3a/U6GGWVTJh75ap62kR1E8Q=="],
+
+    "@mapleai/sdk/@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
+
+    "@mapleai/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "@mapleai/sdk/eslint": ["eslint@9.39.5", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.6", "@eslint/js": "9.39.5", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw=="],
+
+    "@mapleai/sdk/openai": ["openai@5.23.2", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg=="],
+
+    "@mapleai/sdk/prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
+
+    "@mapleai/sdk/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
+
+    "@mapleai/sdk/typescript-eslint": ["typescript-eslint@8.66.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.66.0", "@typescript-eslint/parser": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/utils": "8.66.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw=="],
+
+    "@mapleai/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "@microsoft/api-extractor/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@microsoft/tsdoc-config/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
-    "@opensecret/react/@eslint/js": ["@eslint/js@9.39.5", "", {}, "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A=="],
-
-    "@opensecret/react/@types/bun": ["@types/bun@1.1.13", "", { "dependencies": { "bun-types": "1.1.34" } }, "sha512-KmQxSBgVWCl6RSuerlLGZlIWfdxkKqat0nxN61+qu4y1KDn0Ll3j7v1Pl8GnaL3a/U6GGWVTJh75ap62kR1E8Q=="],
-
-    "@opensecret/react/@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
-
-    "@opensecret/react/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "@opensecret/react/eslint": ["eslint@9.39.5", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.6", "@eslint/js": "9.39.5", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw=="],
-
-    "@opensecret/react/openai": ["openai@5.23.2", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg=="],
-
-    "@opensecret/react/prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
-
-    "@opensecret/react/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
-
-    "@opensecret/react/typescript-eslint": ["typescript-eslint@8.66.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.66.0", "@typescript-eslint/parser": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/utils": "8.66.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw=="],
-
-    "@opensecret/react/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@radix-ui/react-alert-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -1460,27 +1460,27 @@
 
     "@jridgewell/remapping/@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
+    "@mapleai/sdk/@types/bun/bun-types": ["bun-types@1.1.34", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-br5QygTEL/TwB4uQOb96Ky22j4Gq2WxWH/8Oqv20fk5HagwKXo/akB+LiYgSfzexCt6kkcUaVm+bKiPl71xPvw=="],
+
+    "@mapleai/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@mapleai/sdk/eslint/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@mapleai/sdk/eslint/@eslint/eslintrc": ["@eslint/eslintrc@3.3.6", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.3.0", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA=="],
+
+    "@mapleai/sdk/eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "@mapleai/sdk/eslint/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.66.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/type-utils": "8.66.0", "@typescript-eslint/utils": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.66.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A=="],
+
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/parser": ["@typescript-eslint/parser@8.66.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g=="],
+
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.66.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.66.0", "@typescript-eslint/tsconfig-utils": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg=="],
+
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/utils": ["@typescript-eslint/utils@8.66.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA=="],
+
     "@microsoft/tsdoc-config/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@opensecret/react/@types/bun/bun-types": ["bun-types@1.1.34", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-br5QygTEL/TwB4uQOb96Ky22j4Gq2WxWH/8Oqv20fk5HagwKXo/akB+LiYgSfzexCt6kkcUaVm+bKiPl71xPvw=="],
-
-    "@opensecret/react/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@opensecret/react/eslint/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
-
-    "@opensecret/react/eslint/@eslint/eslintrc": ["@eslint/eslintrc@3.3.6", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.3.0", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA=="],
-
-    "@opensecret/react/eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
-
-    "@opensecret/react/eslint/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "@opensecret/react/typescript-eslint/@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.66.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/type-utils": "8.66.0", "@typescript-eslint/utils": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.66.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A=="],
-
-    "@opensecret/react/typescript-eslint/@typescript-eslint/parser": ["@typescript-eslint/parser@8.66.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g=="],
-
-    "@opensecret/react/typescript-eslint/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.66.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.66.0", "@typescript-eslint/tsconfig-utils": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg=="],
-
-    "@opensecret/react/typescript-eslint/@typescript-eslint/utils": ["@typescript-eslint/utils@8.66.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA=="],
 
     "@rushstack/node-core-library/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -1526,68 +1526,68 @@
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "@opensecret/react/@types/bun/bun-types/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-scnD59RpYD91xngrQQLGkE+6UrHUPzeKZWhhjBSa3HSkwjbQc38+q3RoIVEwxQGRw3M+j5hpNAM+lgV3cVormg=="],
+    "@mapleai/sdk/@types/bun/bun-types/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-scnD59RpYD91xngrQQLGkE+6UrHUPzeKZWhhjBSa3HSkwjbQc38+q3RoIVEwxQGRw3M+j5hpNAM+lgV3cVormg=="],
 
-    "@opensecret/react/eslint/@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+    "@mapleai/sdk/eslint/@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/eslint-plugin/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/utils": "8.66.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/utils": "8.66.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/parser/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/parser/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.66.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.66.0", "@typescript-eslint/types": "^8.66.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.66.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.66.0", "@typescript-eslint/types": "^8.66.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.66.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.66.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/typescript-estree/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
 
     "babel-dead-code-elimination/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "babel-dead-code-elimination/@babel/traverse/@babel/generator/@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
-    "@opensecret/react/@types/bun/bun-types/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+    "@mapleai/sdk/@types/bun/bun-types/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/parser/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/parser/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
 
     "babel-dead-code-elimination/@babel/traverse/@babel/generator/@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
-    "@opensecret/react/typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+    "@mapleai/sdk/typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
   }
 }

--- a/apps/maple-research/frontend/package.json
+++ b/apps/maple-research/frontend/package.json
@@ -45,7 +45,7 @@
     "yaml": "^2.8.3"
   },
   "dependencies": {
-    "@opensecret/react": "file:../../../sdk",
+    "@mapleai/sdk": "file:../../../sdk",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/maple-research/frontend/src-tauri/Cargo.lock
+++ b/apps/maple-research/frontend/src-tauri/Cargo.lock
@@ -4724,11 +4724,11 @@ dependencies = [
  "libc",
  "log",
  "maple-proxy",
+ "maple-sdk",
  "objc2-app-kit",
  "objc2-foundation 0.3.2",
  "office_oxide",
  "once_cell",
- "opensecret",
  "openssl",
  "ort",
  "pdf_oxide",
@@ -4776,7 +4776,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "http",
- "opensecret",
+ "maple-sdk",
  "serde",
  "serde_json",
  "tokio",
@@ -4784,6 +4784,41 @@ dependencies = [
  "tower-http 0.6.8",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "maple-sdk"
+version = "3.6.2"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chacha20poly1305",
+ "chrono",
+ "ciborium",
+ "eventsource-stream",
+ "futures",
+ "hex",
+ "hkdf 0.12.4",
+ "http",
+ "p256",
+ "percent-encoding",
+ "pin-project",
+ "reqwest 0.12.28",
+ "ring",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "x25519-dalek",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -5579,41 +5614,6 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
-]
-
-[[package]]
-name = "opensecret"
-version = "3.6.2"
-dependencies = [
- "aes-gcm",
- "anyhow",
- "async-stream",
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "chacha20poly1305",
- "chrono",
- "ciborium",
- "eventsource-stream",
- "futures",
- "hex",
- "hkdf 0.12.4",
- "http",
- "p256",
- "percent-encoding",
- "pin-project",
- "reqwest 0.12.28",
- "ring",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "uuid",
- "x25519-dalek",
- "x509-parser",
- "yasna",
 ]
 
 [[package]]

--- a/apps/maple-research/frontend/src-tauri/Cargo.toml
+++ b/apps/maple-research/frontend/src-tauri/Cargo.toml
@@ -64,7 +64,7 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["std", "
 goose = { git = "https://github.com/aaif-goose/goose.git", rev = "f9c7aaccde4834810dfd13d5efa8f0d39ba28a20", package = "goose", default-features = false }
 goose-providers = { git = "https://github.com/aaif-goose/goose.git", rev = "f9c7aaccde4834810dfd13d5efa8f0d39ba28a20", package = "goose-providers", default-features = false }
 maple-proxy = { version = "0.3.3", path = "../../../../proxy" }
-opensecret = { version = "3.6.2", path = "../../../../sdk/rust" }
+maple-sdk = { version = "3.6.2", path = "../../../../sdk/rust" }
 axum = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }
 rand = "0.8.6"

--- a/apps/maple-research/frontend/src-tauri/src/agent.rs
+++ b/apps/maple-research/frontend/src-tauri/src/agent.rs
@@ -10187,11 +10187,11 @@ mod tests {
     impl provider::MapleInferenceTransport for InertMapleTransport {
         async fn send_inference_request(
             self: Arc<Self>,
-            _request: opensecret::InferenceRequest,
-            _send_budget: opensecret::InferenceSendBudget,
+            _request: maple_sdk::InferenceRequest,
+            _send_budget: maple_sdk::InferenceSendBudget,
             _cancel_token: CancellationToken,
-        ) -> opensecret::Result<opensecret::InferenceResponse> {
-            Err(opensecret::Error::Other(
+        ) -> maple_sdk::Result<maple_sdk::InferenceResponse> {
+            Err(maple_sdk::Error::Other(
                 "test transport should not be called".to_string(),
             ))
         }
@@ -10209,16 +10209,16 @@ mod tests {
     impl provider::MapleInferenceTransport for TerminalMapleTransport {
         async fn send_inference_request(
             self: Arc<Self>,
-            _request: opensecret::InferenceRequest,
-            _send_budget: opensecret::InferenceSendBudget,
+            _request: maple_sdk::InferenceRequest,
+            _send_budget: maple_sdk::InferenceSendBudget,
             _cancel_token: CancellationToken,
-        ) -> opensecret::Result<opensecret::InferenceResponse> {
+        ) -> maple_sdk::Result<maple_sdk::InferenceResponse> {
             match self.0 {
-                TerminalMapleFailure::Session => Err(opensecret::Error::Session(
+                TerminalMapleFailure::Session => Err(maple_sdk::Error::Session(
                     "private exhausted session detail".to_string(),
                 )),
                 TerminalMapleFailure::AttestationVerification => {
-                    Err(opensecret::Error::AttestationVerificationFailed(
+                    Err(maple_sdk::Error::AttestationVerificationFailed(
                         "private attestation detail".to_string(),
                     ))
                 }

--- a/apps/maple-research/frontend/src-tauri/src/agent/developer_tools.rs
+++ b/apps/maple-research/frontend/src-tauri/src/agent/developer_tools.rs
@@ -2457,7 +2457,7 @@ mod tests {
     use goose::providers::base::{ProviderUsage, Usage};
     use goose::session::SessionManager;
     use goose::session::SessionType;
-    use opensecret::{
+    use maple_sdk::{
         WebExtractPage, WebExtractRequest, WebExtractResponse, WebSearchRequest, WebSearchResponse,
         WebSearchResult,
     };
@@ -2473,7 +2473,7 @@ mod tests {
             self: Arc<Self>,
             _request: WebSearchRequest,
             _cancel_token: CancellationToken,
-        ) -> opensecret::Result<WebSearchResponse> {
+        ) -> maple_sdk::Result<WebSearchResponse> {
             Ok(WebSearchResponse {
                 trace_id: None,
                 results: vec![WebSearchResult {
@@ -2490,7 +2490,7 @@ mod tests {
             self: Arc<Self>,
             request: WebExtractRequest,
             _cancel_token: CancellationToken,
-        ) -> opensecret::Result<WebExtractResponse> {
+        ) -> maple_sdk::Result<WebExtractResponse> {
             Ok(WebExtractResponse {
                 trace_id: None,
                 pages: vec![WebExtractPage {

--- a/apps/maple-research/frontend/src-tauri/src/agent/provider.rs
+++ b/apps/maple-research/frontend/src-tauri/src/agent/provider.rs
@@ -11,7 +11,7 @@ use goose_providers::images::ImageFormat;
 use goose_providers::model::ModelConfig;
 use goose_providers::request_log::{start_log, LoggerHandleExt};
 use goose_providers::retry::RetryConfig;
-use opensecret::{
+use maple_sdk::{
     InferenceRequest, InferenceResponse, InferenceSendBudget, OpenSecretClient,
     OpenSecretResponseBody,
 };
@@ -150,7 +150,7 @@ pub(crate) trait MapleInferenceTransport: Send + Sync {
         request: InferenceRequest,
         send_budget: InferenceSendBudget,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<InferenceResponse>;
+    ) -> maple_sdk::Result<InferenceResponse>;
 }
 
 /// A direct SDK client is also a valid transport. Maple's account-scoped auth
@@ -163,11 +163,11 @@ impl MapleInferenceTransport for OpenSecretClient {
         request: InferenceRequest,
         send_budget: InferenceSendBudget,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<InferenceResponse> {
+    ) -> maple_sdk::Result<InferenceResponse> {
         tokio::select! {
             biased;
             _ = cancel_token.cancelled() => {
-                Err(opensecret::Error::Other("Inference request was cancelled".to_string()))
+                Err(maple_sdk::Error::Other("Inference request was cancelled".to_string()))
             }
             response = OpenSecretClient::send_inference_request_with_budget(
                 &self,
@@ -1048,7 +1048,7 @@ fn is_context_length_exceeded_message(text: &str) -> bool {
     mentions_prompt_input_tokens && mentions_limit && mentions_overflow
 }
 
-fn map_opensecret_error(error: opensecret::Error) -> ProviderError {
+fn map_opensecret_error(error: maple_sdk::Error) -> ProviderError {
     log::warn!(
         "OpenSecret inference transport failed ({})",
         opensecret_error_category(&error)
@@ -1056,50 +1056,50 @@ fn map_opensecret_error(error: opensecret::Error) -> ProviderError {
     map_opensecret_error_kind(error)
 }
 
-fn map_opensecret_error_kind(error: opensecret::Error) -> ProviderError {
+fn map_opensecret_error_kind(error: maple_sdk::Error) -> ProviderError {
     match error {
-        opensecret::Error::Authentication(_) | opensecret::Error::Api { status: 401, .. } => {
+        maple_sdk::Error::Authentication(_) | maple_sdk::Error::Api { status: 401, .. } => {
             ProviderError::Authentication(AUTHENTICATION_ERROR_MESSAGE.to_string())
         }
-        opensecret::Error::Api {
+        maple_sdk::Error::Api {
             status: 402,
             message: _,
         } => ProviderError::CreditsExhausted {
             details: "Maple credits are exhausted".to_string(),
             top_up_url: None,
         },
-        opensecret::Error::Api {
+        maple_sdk::Error::Api {
             status: 413,
             message: _,
         } => ProviderError::ContextLengthExceeded(
             "The Maple request exceeds the model's context window".to_string(),
         ),
-        opensecret::Error::Api {
+        maple_sdk::Error::Api {
             status: 400,
             message,
         } if is_context_length_exceeded_message(&message) => ProviderError::ContextLengthExceeded(
             "The Maple request exceeds the model's context window".to_string(),
         ),
-        opensecret::Error::Api {
+        maple_sdk::Error::Api {
             status: 429,
             message: _,
         } => ProviderError::RateLimitExceeded {
             details: "Maple rate limit exceeded".to_string(),
             retry_delay: None,
         },
-        opensecret::Error::Api { status, message: _ } if (500..=599).contains(&status) => {
+        maple_sdk::Error::Api { status, message: _ } if (500..=599).contains(&status) => {
             ProviderError::ServerError(format!("Maple's server returned status {status}"))
         }
-        opensecret::Error::Api {
+        maple_sdk::Error::Api {
             status: 404,
             message: _,
         } => ProviderError::EndpointNotFound(
             "The Maple inference endpoint was not found".to_string(),
         ),
-        opensecret::Error::Api { status, message: _ } => {
+        maple_sdk::Error::Api { status, message: _ } => {
             ProviderError::RequestFailed(format!("Maple request failed with status {status}"))
         }
-        opensecret::Error::Http(error) => {
+        maple_sdk::Error::Http(error) => {
             if error.is_timeout() {
                 ProviderError::NetworkError("The Maple request timed out".to_string())
             } else if error.is_connect() {
@@ -1108,30 +1108,30 @@ fn map_opensecret_error_kind(error: opensecret::Error) -> ProviderError {
                 ProviderError::NetworkError("The Maple network request failed".to_string())
             }
         }
-        opensecret::Error::AttestationVerificationFailed(_) => {
+        maple_sdk::Error::AttestationVerificationFailed(_) => {
             ProviderError::ExecutionError(ATTESTATION_VERIFICATION_ERROR_MESSAGE.to_string())
         }
-        opensecret::Error::Session(_)
-        | opensecret::Error::KeyExchange(_)
-        | opensecret::Error::Encryption(_)
-        | opensecret::Error::Decryption(_)
-        | opensecret::Error::InvalidResponse(_)
-        | opensecret::Error::Crypto(_)
-        | opensecret::Error::Cbor(_)
-        | opensecret::Error::Io(_)
-        | opensecret::Error::Utf8(_)
-        | opensecret::Error::Base64Decode(_) => {
+        maple_sdk::Error::Session(_)
+        | maple_sdk::Error::KeyExchange(_)
+        | maple_sdk::Error::Encryption(_)
+        | maple_sdk::Error::Decryption(_)
+        | maple_sdk::Error::InvalidResponse(_)
+        | maple_sdk::Error::Crypto(_)
+        | maple_sdk::Error::Cbor(_)
+        | maple_sdk::Error::Io(_)
+        | maple_sdk::Error::Utf8(_)
+        | maple_sdk::Error::Base64Decode(_) => {
             ProviderError::ExecutionError(SECURE_CONNECTION_ERROR_MESSAGE.to_string())
         }
-        opensecret::Error::Serialization(_)
-        | opensecret::Error::Configuration(_)
-        | opensecret::Error::Other(_) => ProviderError::ExecutionError(
+        maple_sdk::Error::Serialization(_)
+        | maple_sdk::Error::Configuration(_)
+        | maple_sdk::Error::Other(_) => ProviderError::ExecutionError(
             "Maple could not prepare the encrypted request".to_string(),
         ),
     }
 }
 
-fn map_response_stream_error(error: opensecret::Error) -> std::io::Error {
+fn map_response_stream_error(error: maple_sdk::Error) -> std::io::Error {
     log::warn!(
         "Failed to read encrypted Maple response stream ({})",
         opensecret_error_category(&error)
@@ -1155,25 +1155,25 @@ fn secure_connection_stream_error(error: &anyhow::Error) -> Option<ProviderError
     })
 }
 
-pub(crate) fn opensecret_error_category(error: &opensecret::Error) -> &'static str {
+pub(crate) fn opensecret_error_category(error: &maple_sdk::Error) -> &'static str {
     match error {
-        opensecret::Error::Http(_) => "http",
-        opensecret::Error::Serialization(_) => "serialization",
-        opensecret::Error::Cbor(_) => "cbor",
-        opensecret::Error::Crypto(_) => "crypto",
-        opensecret::Error::AttestationVerificationFailed(_) => "attestation",
-        opensecret::Error::Session(_) => "session",
-        opensecret::Error::KeyExchange(_) => "key_exchange",
-        opensecret::Error::Encryption(_) => "encryption",
-        opensecret::Error::Decryption(_) => "decryption",
-        opensecret::Error::Authentication(_) => "authentication",
-        opensecret::Error::InvalidResponse(_) => "invalid_response",
-        opensecret::Error::Api { .. } => "api",
-        opensecret::Error::Configuration(_) => "configuration",
-        opensecret::Error::Io(_) => "io",
-        opensecret::Error::Utf8(_) => "utf8",
-        opensecret::Error::Base64Decode(_) => "base64",
-        opensecret::Error::Other(_) => "other",
+        maple_sdk::Error::Http(_) => "http",
+        maple_sdk::Error::Serialization(_) => "serialization",
+        maple_sdk::Error::Cbor(_) => "cbor",
+        maple_sdk::Error::Crypto(_) => "crypto",
+        maple_sdk::Error::AttestationVerificationFailed(_) => "attestation",
+        maple_sdk::Error::Session(_) => "session",
+        maple_sdk::Error::KeyExchange(_) => "key_exchange",
+        maple_sdk::Error::Encryption(_) => "encryption",
+        maple_sdk::Error::Decryption(_) => "decryption",
+        maple_sdk::Error::Authentication(_) => "authentication",
+        maple_sdk::Error::InvalidResponse(_) => "invalid_response",
+        maple_sdk::Error::Api { .. } => "api",
+        maple_sdk::Error::Configuration(_) => "configuration",
+        maple_sdk::Error::Io(_) => "io",
+        maple_sdk::Error::Utf8(_) => "utf8",
+        maple_sdk::Error::Base64Decode(_) => "base64",
+        maple_sdk::Error::Other(_) => "other",
     }
 }
 
@@ -1200,7 +1200,7 @@ mod tests {
     struct FakeTransport {
         requests: Mutex<Vec<CapturedRequest>>,
         send_limits: Mutex<Vec<usize>>,
-        responses: Mutex<VecDeque<opensecret::Result<InferenceResponse>>>,
+        responses: Mutex<VecDeque<maple_sdk::Result<InferenceResponse>>>,
         request_notify: Notify,
     }
 
@@ -1217,9 +1217,9 @@ mod tests {
             _request: InferenceRequest,
             _send_budget: InferenceSendBudget,
             cancel_token: CancellationToken,
-        ) -> opensecret::Result<InferenceResponse> {
+        ) -> maple_sdk::Result<InferenceResponse> {
             cancel_token.cancelled().await;
-            Err(opensecret::Error::Other(
+            Err(maple_sdk::Error::Other(
                 "Pending transport was cancelled".to_string(),
             ))
         }
@@ -1238,7 +1238,7 @@ mod tests {
             Self::with_results(responses.into_iter().map(Ok).collect())
         }
 
-        fn with_results(responses: Vec<opensecret::Result<InferenceResponse>>) -> Self {
+        fn with_results(responses: Vec<maple_sdk::Result<InferenceResponse>>) -> Self {
             Self {
                 requests: Mutex::new(Vec::new()),
                 send_limits: Mutex::new(Vec::new()),
@@ -1277,13 +1277,13 @@ mod tests {
             request: InferenceRequest,
             send_budget: InferenceSendBudget,
             _cancel_token: CancellationToken,
-        ) -> opensecret::Result<InferenceResponse> {
+        ) -> maple_sdk::Result<InferenceResponse> {
             self.send_limits
                 .lock()
                 .expect("send limit lock")
                 .push(send_budget.remaining());
             if !send_budget.try_reserve_send() {
-                return Err(opensecret::Error::Other(
+                return Err(maple_sdk::Error::Other(
                     "Inference request send budget exhausted".to_string(),
                 ));
             }
@@ -1316,7 +1316,7 @@ mod tests {
             _request: InferenceRequest,
             send_budget: InferenceSendBudget,
             _cancel_token: CancellationToken,
-        ) -> opensecret::Result<InferenceResponse> {
+        ) -> maple_sdk::Result<InferenceResponse> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             assert!(send_budget.try_reserve_send());
             assert!(send_budget.try_reserve_send());
@@ -1326,7 +1326,7 @@ mod tests {
 
     fn response_with_items(
         status: u16,
-        items: Vec<opensecret::Result<Vec<u8>>>,
+        items: Vec<maple_sdk::Result<Vec<u8>>>,
         retry_after: Option<&str>,
     ) -> InferenceResponse {
         let body: OpenSecretResponseBody = Box::pin(futures_util::stream::iter(
@@ -1380,7 +1380,7 @@ mod tests {
     ) -> InferenceResponse {
         let body: OpenSecretResponseBody = Box::pin(futures_util::stream::once(async move {
             body_polls.fetch_add(1, Ordering::SeqCst);
-            Ok::<_, opensecret::Error>(b"private upstream capacity detail".to_vec().into())
+            Ok::<_, maple_sdk::Error>(b"private upstream capacity detail".to_vec().into())
         }));
         let mut response = InferenceResponse::new(body);
         *response.status_mut() =
@@ -2075,7 +2075,7 @@ mod tests {
             200,
             vec![
                 Ok(first_chunk),
-                Err(opensecret::Error::InvalidResponse(
+                Err(maple_sdk::Error::InvalidResponse(
                     "private post-item stream failure".to_string(),
                 )),
             ],
@@ -2134,7 +2134,7 @@ mod tests {
             200,
             vec![
                 Ok(usage_chunk),
-                Err(opensecret::Error::InvalidResponse(
+                Err(maple_sdk::Error::InvalidResponse(
                     "private post-usage stream failure".to_string(),
                 )),
             ],
@@ -2558,7 +2558,7 @@ mod tests {
             200,
             vec![
                 Ok(complete_tool_call_event()),
-                Err(opensecret::Error::InvalidResponse(
+                Err(maple_sdk::Error::InvalidResponse(
                     "private completed tool stream failure".to_string(),
                 )),
             ],
@@ -2854,7 +2854,7 @@ mod tests {
         let retry_config = RetryConfig::new(3, 0, 1.0, 0).transient_only();
         let errors = [
             map_http_error(tauri::http::StatusCode::FORBIDDEN, None),
-            map_opensecret_error(opensecret::Error::Api {
+            map_opensecret_error(maple_sdk::Error::Api {
                 status: 403,
                 message: "private plan detail".to_string(),
             }),
@@ -2923,18 +2923,18 @@ mod tests {
     fn secure_connection_sdk_errors_are_fixed_and_non_transient() {
         let retry_config = RetryConfig::new(3, 0, 1.0, 0).transient_only();
         let errors = vec![
-            opensecret::Error::Session("private session detail".to_string()),
-            opensecret::Error::KeyExchange("private key detail".to_string()),
-            opensecret::Error::Encryption("private encryption detail".to_string()),
-            opensecret::Error::Decryption("private decryption detail".to_string()),
-            opensecret::Error::InvalidResponse("private response detail".to_string()),
-            opensecret::Error::Crypto("private crypto detail".to_string()),
-            opensecret::Error::Cbor("private cbor detail".to_string()),
-            opensecret::Error::Io(std::io::Error::other("private io detail")),
-            opensecret::Error::Utf8(
+            maple_sdk::Error::Session("private session detail".to_string()),
+            maple_sdk::Error::KeyExchange("private key detail".to_string()),
+            maple_sdk::Error::Encryption("private encryption detail".to_string()),
+            maple_sdk::Error::Decryption("private decryption detail".to_string()),
+            maple_sdk::Error::InvalidResponse("private response detail".to_string()),
+            maple_sdk::Error::Crypto("private crypto detail".to_string()),
+            maple_sdk::Error::Cbor("private cbor detail".to_string()),
+            maple_sdk::Error::Io(std::io::Error::other("private io detail")),
+            maple_sdk::Error::Utf8(
                 String::from_utf8(vec![0xff]).expect_err("invalid UTF-8 fixture"),
             ),
-            opensecret::Error::Base64Decode(base64::DecodeError::InvalidByte(0, b'%')),
+            maple_sdk::Error::Base64Decode(base64::DecodeError::InvalidByte(0, b'%')),
         ];
 
         for error in errors {
@@ -3011,7 +3011,7 @@ mod tests {
     #[tokio::test]
     async fn terminal_attestation_failure_is_one_send_and_is_latched_for_the_run() {
         let transport = Arc::new(FakeTransport::with_results(vec![
-            Err(opensecret::Error::AttestationVerificationFailed(
+            Err(maple_sdk::Error::AttestationVerificationFailed(
                 "private attestation detail".to_string(),
             )),
             Ok(fragmented_success_response()),
@@ -3047,7 +3047,7 @@ mod tests {
     #[tokio::test]
     async fn terminal_secure_connection_failure_is_one_send_and_is_latched_for_the_run() {
         let transport = Arc::new(FakeTransport::with_results(vec![
-            Err(opensecret::Error::Session(
+            Err(maple_sdk::Error::Session(
                 "private exhausted session detail".to_string(),
             )),
             Ok(fragmented_success_response()),
@@ -3084,7 +3084,7 @@ mod tests {
     async fn terminal_secure_stream_failure_is_one_send_and_is_latched_for_the_run() {
         let failed = response_with_items(
             200,
-            vec![Err(opensecret::Error::Decryption(
+            vec![Err(maple_sdk::Error::Decryption(
                 "private lazy decryption detail".to_string(),
             ))],
             None,
@@ -3141,7 +3141,7 @@ mod tests {
             assert!(!error.to_string().contains(PRIVATE_DETAIL));
             assert!(!format!("{error:?}").contains(PRIVATE_DETAIL));
 
-            let sdk_error = map_opensecret_error(opensecret::Error::Api {
+            let sdk_error = map_opensecret_error(maple_sdk::Error::Api {
                 status,
                 message: PRIVATE_DETAIL.to_string(),
             });
@@ -3152,7 +3152,7 @@ mod tests {
 
     #[test]
     fn sdk_context_error_is_classified_without_exposing_provider_message() {
-        let error = map_opensecret_error(opensecret::Error::Api {
+        let error = map_opensecret_error(maple_sdk::Error::Api {
             status: 400,
             message: "maximum context length exceeded; private token counts".to_string(),
         });

--- a/apps/maple-research/frontend/src-tauri/src/agent/web_tools.rs
+++ b/apps/maple-research/frontend/src-tauri/src/agent/web_tools.rs
@@ -1,5 +1,5 @@
 use crate::maple_api::MapleWebTransport;
-use opensecret::{
+use maple_sdk::{
     WebExtractRequest, WebSearchFilters, WebSearchLens, WebSearchRequest, WebSearchResult,
     WebSearchWorkflow,
 };
@@ -251,7 +251,7 @@ pub(crate) async fn execute_web_search(
         return Err("Web search was cancelled".to_string());
     }
 
-    let opensecret::WebSearchResponse {
+    let maple_sdk::WebSearchResponse {
         trace_id,
         mut results,
     } = response;
@@ -302,7 +302,7 @@ pub(crate) async fn execute_open_url(
         return Err("URL extraction was cancelled".to_string());
     }
 
-    let opensecret::WebExtractResponse { trace_id, pages } = response;
+    let maple_sdk::WebExtractResponse { trace_id, pages } = response;
     let page = pages
         .into_iter()
         .find(|page| normalize_public_https_url(&page.url).is_ok_and(|page_url| page_url == url))
@@ -560,7 +560,7 @@ fn bound_web_tool_error(error: String, final_output_limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opensecret::{WebExtractPage, WebExtractResponse, WebSearchResponse, WebSearchResult};
+    use maple_sdk::{WebExtractPage, WebExtractResponse, WebSearchResponse, WebSearchResult};
     use std::sync::Mutex as StdMutex;
 
     struct MockTransport {
@@ -577,11 +577,11 @@ mod tests {
             self: Arc<Self>,
             request: WebSearchRequest,
             cancel_token: CancellationToken,
-        ) -> opensecret::Result<WebSearchResponse> {
+        ) -> maple_sdk::Result<WebSearchResponse> {
             self.searches.lock().unwrap().push(request);
             if self.wait_for_cancellation {
                 cancel_token.cancelled().await;
-                return Err(opensecret::Error::Other("cancelled".to_string()));
+                return Err(maple_sdk::Error::Other("cancelled".to_string()));
             }
             Ok(self.search_response.clone())
         }
@@ -590,11 +590,11 @@ mod tests {
             self: Arc<Self>,
             request: WebExtractRequest,
             cancel_token: CancellationToken,
-        ) -> opensecret::Result<WebExtractResponse> {
+        ) -> maple_sdk::Result<WebExtractResponse> {
             self.extracts.lock().unwrap().push(request);
             if self.wait_for_cancellation {
                 cancel_token.cancelled().await;
-                return Err(opensecret::Error::Other("cancelled".to_string()));
+                return Err(maple_sdk::Error::Other("cancelled".to_string()));
             }
             Ok(self.extract_response.clone())
         }

--- a/apps/maple-research/frontend/src-tauri/src/maple_api.rs
+++ b/apps/maple-research/frontend/src-tauri/src/maple_api.rs
@@ -1,5 +1,5 @@
 use crate::open_secret_config::configured_pcr0_environment;
-use opensecret::{
+use maple_sdk::{
     InferenceRequest, InferenceResponse, InferenceSendBudget, OpenSecretClient, WebExtractRequest,
     WebExtractResponse, WebSearchRequest, WebSearchResponse,
 };
@@ -260,11 +260,11 @@ impl MapleApiSession {
         request: InferenceRequest,
         send_budget: InferenceSendBudget,
         cancel_token: CancellationToken,
-    ) -> Result<InferenceResponse, opensecret::Error> {
+    ) -> Result<InferenceResponse, maple_sdk::Error> {
         let snapshot = self
             .client_snapshot()
             .await
-            .map_err(opensecret::Error::Authentication)?;
+            .map_err(maple_sdk::Error::Authentication)?;
         let operation_cancel = cancel_token.child_token();
         let _cancel_on_drop = CancelOperationOnDrop(operation_cancel.clone());
         let session = Arc::clone(&self);
@@ -272,7 +272,7 @@ impl MapleApiSession {
             let response = tokio::select! {
                 biased;
                 _ = operation_cancel.cancelled() => {
-                    Err(opensecret::Error::Other("Inference request was cancelled".to_string()))
+                    Err(maple_sdk::Error::Other("Inference request was cancelled".to_string()))
                 }
                 response = snapshot
                     .client
@@ -290,11 +290,11 @@ impl MapleApiSession {
         self: Arc<Self>,
         request: WebSearchRequest,
         cancel_token: CancellationToken,
-    ) -> Result<WebSearchResponse, opensecret::Error> {
+    ) -> Result<WebSearchResponse, maple_sdk::Error> {
         let snapshot = self
             .client_snapshot()
             .await
-            .map_err(opensecret::Error::Authentication)?;
+            .map_err(maple_sdk::Error::Authentication)?;
         let operation_cancel = cancel_token.child_token();
         let _cancel_on_drop = CancelOperationOnDrop(operation_cancel.clone());
         let session = Arc::clone(&self);
@@ -302,7 +302,7 @@ impl MapleApiSession {
             let response = tokio::select! {
                 biased;
                 _ = operation_cancel.cancelled() => {
-                    Err(opensecret::Error::Other("Web search was cancelled".to_string()))
+                    Err(maple_sdk::Error::Other("Web search was cancelled".to_string()))
                 }
                 response = snapshot.client.web_search(request) => response,
             };
@@ -318,11 +318,11 @@ impl MapleApiSession {
         self: Arc<Self>,
         request: WebExtractRequest,
         cancel_token: CancellationToken,
-    ) -> Result<WebExtractResponse, opensecret::Error> {
+    ) -> Result<WebExtractResponse, maple_sdk::Error> {
         let snapshot = self
             .client_snapshot()
             .await
-            .map_err(opensecret::Error::Authentication)?;
+            .map_err(maple_sdk::Error::Authentication)?;
         let operation_cancel = cancel_token.child_token();
         let _cancel_on_drop = CancelOperationOnDrop(operation_cancel.clone());
         let session = Arc::clone(&self);
@@ -330,7 +330,7 @@ impl MapleApiSession {
             let response = tokio::select! {
                 biased;
                 _ = operation_cancel.cancelled() => {
-                    Err(opensecret::Error::Other("Web extraction was cancelled".to_string()))
+                    Err(maple_sdk::Error::Other("Web extraction was cancelled".to_string()))
                 }
                 response = snapshot.client.web_extract(request) => response,
             };
@@ -369,9 +369,9 @@ pub(crate) fn test_maple_api_session(user_id: &str) -> Arc<MapleApiSession> {
     )
 }
 
-fn map_operation_join_error(error: tokio::task::JoinError) -> opensecret::Error {
+fn map_operation_join_error(error: tokio::task::JoinError) -> maple_sdk::Error {
     log::warn!("Maple API operation task failed: {error}");
-    opensecret::Error::Other("Maple API operation failed".to_string())
+    maple_sdk::Error::Other("Maple API operation failed".to_string())
 }
 
 #[async_trait::async_trait]
@@ -380,13 +380,13 @@ pub(crate) trait MapleWebTransport: Send + Sync {
         self: Arc<Self>,
         request: WebSearchRequest,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<WebSearchResponse>;
+    ) -> maple_sdk::Result<WebSearchResponse>;
 
     async fn web_extract(
         self: Arc<Self>,
         request: WebExtractRequest,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<WebExtractResponse>;
+    ) -> maple_sdk::Result<WebExtractResponse>;
 }
 
 #[async_trait::async_trait]
@@ -395,7 +395,7 @@ impl MapleWebTransport for MapleApiSession {
         self: Arc<Self>,
         request: WebSearchRequest,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<WebSearchResponse> {
+    ) -> maple_sdk::Result<WebSearchResponse> {
         MapleApiSession::web_search(self, request, cancel_token).await
     }
 
@@ -403,7 +403,7 @@ impl MapleWebTransport for MapleApiSession {
         self: Arc<Self>,
         request: WebExtractRequest,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<WebExtractResponse> {
+    ) -> maple_sdk::Result<WebExtractResponse> {
         MapleApiSession::web_extract(self, request, cancel_token).await
     }
 }
@@ -415,7 +415,7 @@ impl crate::agent::provider::MapleInferenceTransport for MapleApiSession {
         request: InferenceRequest,
         send_budget: InferenceSendBudget,
         cancel_token: CancellationToken,
-    ) -> opensecret::Result<InferenceResponse> {
+    ) -> maple_sdk::Result<InferenceResponse> {
         MapleApiSession::send_inference_request(self, request, send_budget, cancel_token).await
     }
 }
@@ -452,7 +452,7 @@ fn capture_tokens(client: &OpenSecretClient) -> Result<TokenPair, String> {
     })
 }
 
-fn map_sdk_error(error: opensecret::Error) -> String {
+fn map_sdk_error(error: maple_sdk::Error) -> String {
     log::warn!(
         "OpenSecret SDK authentication operation failed ({})",
         crate::agent::provider::opensecret_error_category(&error)
@@ -699,7 +699,7 @@ mod tests {
     use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
     use ciborium::value::Value as CborValue;
     use goose_providers::{base::Provider, conversation::message::Message, model::ModelConfig};
-    use opensecret::types::KeyExchangeRequest;
+    use maple_sdk::types::KeyExchangeRequest;
     use std::sync::Mutex as StdMutex;
     use tokio::sync::Notify;
 
@@ -754,7 +754,7 @@ mod tests {
 
     #[derive(Clone)]
     struct RefreshThenStallState {
-        key_pair: Arc<opensecret::crypto::KeyPair>,
+        key_pair: Arc<maple_sdk::crypto::KeyPair>,
         session_key: [u8; 32],
         session_id: String,
         retry_started: Arc<Notify>,
@@ -808,13 +808,13 @@ mod tests {
         Json(request): Json<KeyExchangeRequest>,
     ) -> Json<serde_json::Value> {
         let client_public_bytes = BASE64.decode(request.client_public_key).unwrap();
-        let client_public_key = opensecret::crypto::PublicKey::from(
+        let client_public_key = maple_sdk::crypto::PublicKey::from(
             <[u8; 32]>::try_from(client_public_bytes.as_slice()).unwrap(),
         );
         let shared_secret =
-            opensecret::crypto::derive_shared_secret(&state.key_pair.secret, &client_public_key);
+            maple_sdk::crypto::derive_shared_secret(&state.key_pair.secret, &client_public_key);
         let encrypted_session_key = BASE64.encode(
-            opensecret::crypto::encrypt_data(shared_secret.as_bytes(), &state.session_key).unwrap(),
+            maple_sdk::crypto::encrypt_data(shared_secret.as_bytes(), &state.session_key).unwrap(),
         );
         Json(serde_json::json!({
             "encrypted_session_key": encrypted_session_key,
@@ -830,7 +830,7 @@ mod tests {
             "refresh_token": "fresh_refresh",
         }))
         .unwrap();
-        let encrypted = opensecret::crypto::encrypt_data(&state.session_key, &plaintext).unwrap();
+        let encrypted = maple_sdk::crypto::encrypt_data(&state.session_key, &plaintext).unwrap();
         Json(serde_json::json!({ "encrypted": BASE64.encode(encrypted) }))
     }
 
@@ -854,7 +854,7 @@ mod tests {
     }
 
     async fn refresh_then_stall_fixture() -> RefreshThenStallFixture {
-        let key_pair = Arc::new(opensecret::crypto::generate_key_pair());
+        let key_pair = Arc::new(maple_sdk::crypto::generate_key_pair());
         let retry_started = Arc::new(Notify::new());
         let state = RefreshThenStallState {
             key_pair,
@@ -1067,7 +1067,7 @@ mod tests {
             .web_search(WebSearchRequest::new("maple privacy"), search_cancel)
             .await;
         assert!(
-            matches!(search, Err(opensecret::Error::Other(message)) if message.contains("cancelled"))
+            matches!(search, Err(maple_sdk::Error::Other(message)) if message.contains("cancelled"))
         );
 
         let extract_cancel = CancellationToken::new();
@@ -1079,7 +1079,7 @@ mod tests {
             )
             .await;
         assert!(
-            matches!(extract, Err(opensecret::Error::Other(message)) if message.contains("cancelled"))
+            matches!(extract, Err(maple_sdk::Error::Other(message)) if message.contains("cancelled"))
         );
 
         let after = session.auth_snapshot().await.unwrap();

--- a/apps/maple-research/frontend/src/ai/OpenAIContext.tsx
+++ b/apps/maple-research/frontend/src/ai/OpenAIContext.tsx
@@ -1,5 +1,5 @@
 import OpenAI from "openai";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { OpenAIContext } from "./OpenAIContextDef";
 
 export const OpenAIProvider = ({ children }: { children: React.ReactNode }) => {

--- a/apps/maple-research/frontend/src/app.tsx
+++ b/apps/maple-research/frontend/src/app.tsx
@@ -4,7 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip.tsx";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { routeTree } from "./routeTree.gen";
-import { useOpenSecret, OpenSecretProvider } from "@opensecret/react";
+import { useOpenSecret, OpenSecretProvider } from "@mapleai/sdk";
 import { OpenAIProvider } from "./ai/OpenAIContext";
 import { LocalStateProvider } from "./state/LocalStateContext";
 import { ErrorFallback } from "./components/ErrorFallback";

--- a/apps/maple-research/frontend/src/billing/billingService.ts
+++ b/apps/maple-research/frontend/src/billing/billingService.ts
@@ -1,4 +1,4 @@
-import { OpenSecretContextType } from "@opensecret/react";
+import { OpenSecretContextType } from "@mapleai/sdk";
 import {
   fetchBillingStatus,
   fetchPortalUrl,

--- a/apps/maple-research/frontend/src/components/AccountMenu.tsx
+++ b/apps/maple-research/frontend/src/components/AccountMenu.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { AlertCircle, Settings } from "lucide-react";
 import { getBillingService } from "@/billing/billingService";
 import { CreditUsage } from "@/components/CreditUsage";

--- a/apps/maple-research/frontend/src/components/AgentMode.tsx
+++ b/apps/maple-research/frontend/src/components/AgentMode.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   useState
 } from "react";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { useOpenAI } from "@/ai/useOpenAi";
 import {
   AlertCircle,

--- a/apps/maple-research/frontend/src/components/AppleAuthProvider.test.tsx
+++ b/apps/maple-research/frontend/src/components/AppleAuthProvider.test.tsx
@@ -81,8 +81,8 @@ function appleEvent(type: "AppleIDSignInOnSuccess" | "AppleIDSignInOnFailure", d
 }
 
 let currentOpenSecret: Record<string, unknown>;
-const realOpenSecret = await import("@opensecret/react");
-mock.module("@opensecret/react", () => ({
+const realOpenSecret = await import("@mapleai/sdk");
+mock.module("@mapleai/sdk", () => ({
   ...realOpenSecret,
   useOpenSecret: () => currentOpenSecret
 }));

--- a/apps/maple-research/frontend/src/components/AppleAuthProvider.tsx
+++ b/apps/maple-research/frontend/src/components/AppleAuthProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { v4 as uuidv4 } from "uuid";
 import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";

--- a/apps/maple-research/frontend/src/components/AuthenticatedHomeContent.tsx
+++ b/apps/maple-research/frontend/src/components/AuthenticatedHomeContent.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode
 } from "react";
 import { useLocation, useRouter } from "@tanstack/react-router";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { ProjectDetailView } from "@/components/ProjectDetailView";
 import { UnifiedChat } from "@/components/UnifiedChat";
 import {

--- a/apps/maple-research/frontend/src/components/BillingServiceProvider.tsx
+++ b/apps/maple-research/frontend/src/components/BillingServiceProvider.tsx
@@ -1,4 +1,4 @@
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { initBillingService } from "@/billing/billingService";
 
 export function BillingServiceProvider({ children }: { children: React.ReactNode }) {

--- a/apps/maple-research/frontend/src/components/ChatHistoryList.tsx
+++ b/apps/maple-research/frontend/src/components/ChatHistoryList.tsx
@@ -31,11 +31,7 @@ import { RenameChatDialog } from "@/components/RenameChatDialog";
 import { DeleteChatDialog } from "@/components/DeleteChatDialog";
 import { BulkDeleteDialog } from "@/components/BulkDeleteDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  useOpenSecret,
-  type Conversation,
-  type ConversationProjectListItem
-} from "@opensecret/react";
+import { useOpenSecret, type Conversation, type ConversationProjectListItem } from "@mapleai/sdk";
 import { useRouter } from "@tanstack/react-router";
 import { useSelectedProjectState } from "@/state/useLocalState";
 import { ConversationProjectDialog } from "@/components/ConversationProjectDialog";

--- a/apps/maple-research/frontend/src/components/ConversationProjectPicker.tsx
+++ b/apps/maple-research/frontend/src/components/ConversationProjectPicker.tsx
@@ -1,6 +1,6 @@
 import { Check, Folder, FolderOpen } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/utils/utils";
 import { listAllConversationProjects } from "@/utils/paginatedLists";

--- a/apps/maple-research/frontend/src/components/DeepLinkHandler.test.tsx
+++ b/apps/maple-research/frontend/src/components/DeepLinkHandler.test.tsx
@@ -38,7 +38,7 @@ let deepLinkListener: ((event: DeepLinkEvent) => void) | undefined;
 let currentUser: { id: string } | undefined;
 const unlisten = mock(() => {});
 
-mock.module("@opensecret/react", () => ({
+mock.module("@mapleai/sdk", () => ({
   useOpenSecret: () => ({ auth: { user: currentUser } })
 }));
 

--- a/apps/maple-research/frontend/src/components/DeepLinkHandler.tsx
+++ b/apps/maple-research/frontend/src/components/DeepLinkHandler.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { isTauri } from "@/utils/platform";
 import { listen } from "@tauri-apps/api/event";
 import { getSafeInternalRedirect } from "@/utils/internalRedirect";

--- a/apps/maple-research/frontend/src/components/GuestPaymentWarningDialog.tsx
+++ b/apps/maple-research/frontend/src/components/GuestPaymentWarningDialog.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/dialog";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { AlertTriangle, LogOut, CreditCard } from "lucide-react";
 import {
   clearMapleApiAuthForUser,

--- a/apps/maple-research/frontend/src/components/ModelSelector.tsx
+++ b/apps/maple-research/frontend/src/components/ModelSelector.tsx
@@ -8,7 +8,7 @@ import {
   DropdownMenuSeparator
 } from "@/components/ui/dropdown-menu";
 import { useBillingState, useModelState } from "@/state/useLocalState";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
 import { POWERFUL_MODEL_ALIAS, QUICK_MODEL_ALIAS } from "@/utils/utils";

--- a/apps/maple-research/frontend/src/components/MoveChatsDialog.tsx
+++ b/apps/maple-research/frontend/src/components/MoveChatsDialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog";
-import type { ConversationProjectListItem } from "@opensecret/react";
+import type { ConversationProjectListItem } from "@mapleai/sdk";
 import { cn } from "@/utils/utils";
 
 interface MoveChatsDialogProps {

--- a/apps/maple-research/frontend/src/components/PasswordResetConfirmForm.tsx
+++ b/apps/maple-research/frontend/src/components/PasswordResetConfirmForm.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AlertDestructive } from "@/components/AlertDestructive";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { useNavigate } from "@tanstack/react-router";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";

--- a/apps/maple-research/frontend/src/components/PasswordResetRequestForm.tsx
+++ b/apps/maple-research/frontend/src/components/PasswordResetRequestForm.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AlertDestructive } from "@/components/AlertDestructive";
-import { generateSecureSecret, hashSecret, useOpenSecret } from "@opensecret/react";
+import { generateSecureSecret, hashSecret, useOpenSecret } from "@mapleai/sdk";
 import { PasswordResetConfirmForm } from "./PasswordResetConfirmForm";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {

--- a/apps/maple-research/frontend/src/components/ProjectDetailView.tsx
+++ b/apps/maple-research/frontend/src/components/ProjectDetailView.tsx
@@ -12,7 +12,7 @@ import {
   SquarePen,
   Trash2
 } from "lucide-react";
-import { useOpenSecret, type Conversation } from "@opensecret/react";
+import { useOpenSecret, type Conversation } from "@mapleai/sdk";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Sidebar, SidebarToggle } from "@/components/Sidebar";
 import { ResizableSidebarLayout } from "@/components/ResizableSidebarLayout";

--- a/apps/maple-research/frontend/src/components/Sidebar.tsx
+++ b/apps/maple-research/frontend/src/components/Sidebar.tsx
@@ -34,7 +34,7 @@ import {
 } from "@/state/useLocalState";
 import { SIDEBAR_MAX_WIDTH_CLASS, SIDEBAR_WIDTH_CLASS } from "@/constants/layout";
 import { isTauriDesktop } from "@/utils/platform";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { FEATURE_FLAGS, flagsClient, isForcedOn } from "@/services/flags";
 import { rememberWorkspaceMode } from "@/services/workspaceModePreference";
 import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";

--- a/apps/maple-research/frontend/src/components/TopNav.tsx
+++ b/apps/maple-research/frontend/src/components/TopNav.tsx
@@ -1,7 +1,7 @@
 import { Link, useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { cn } from "@/utils/utils";
 import { Button } from "./ui/button";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { Menu, X } from "lucide-react";
 import { useState, type ReactNode } from "react";
 

--- a/apps/maple-research/frontend/src/components/UnifiedChat.tsx
+++ b/apps/maple-research/frontend/src/components/UnifiedChat.tsx
@@ -73,7 +73,7 @@ import {
   findOpenSecretInferenceCapacityError,
   OPEN_SECRET_INFERENCE_SEND_LIMIT_HEADER,
   useOpenSecret
-} from "@opensecret/react";
+} from "@mapleai/sdk";
 import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
 import { DocumentPlatformDialog } from "@/components/DocumentPlatformDialog";
 import { ContextLimitDialog } from "@/components/ContextLimitDialog";

--- a/apps/maple-research/frontend/src/components/VerificationModal.tsx
+++ b/apps/maple-research/frontend/src/components/VerificationModal.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle
 } from "@/components/ui/dialog";
 import { useQueryClient } from "@tanstack/react-query";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { useRouter } from "@tanstack/react-router";
 import { useState, useEffect } from "react";
 import { Loader2, CheckCircle, LogOut } from "lucide-react";

--- a/apps/maple-research/frontend/src/components/apikeys/ApiCreditsSection.tsx
+++ b/apps/maple-research/frontend/src/components/apikeys/ApiCreditsSection.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Loader2, CreditCard, Bitcoin, Coins, CheckCircle, Edit } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { getBillingService } from "@/billing/billingService";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { isMobile, isTauri } from "@/utils/platform";
 import {
   MIN_PURCHASE_CREDITS,

--- a/apps/maple-research/frontend/src/components/settings/AccountSettings.tsx
+++ b/apps/maple-research/frontend/src/components/settings/AccountSettings.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import {
   CheckCircle,
   ChevronRight,

--- a/apps/maple-research/frontend/src/components/settings/AgentConnectionsSettings.tsx
+++ b/apps/maple-research/frontend/src/components/settings/AgentConnectionsSettings.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { AlertCircle, Loader2, Play, RefreshCw, Server, ShieldCheck, Square } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";

--- a/apps/maple-research/frontend/src/components/settings/DeleteAccountSettings.tsx
+++ b/apps/maple-research/frontend/src/components/settings/DeleteAccountSettings.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import { Link, useBlocker } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
-import { generateSecureSecret, hashSecret, useOpenSecret } from "@opensecret/react";
+import { generateSecureSecret, hashSecret, useOpenSecret } from "@mapleai/sdk";
 import { AlertTriangle, Loader2 } from "lucide-react";
 import { shouldWarnBeforeAccountDeletion } from "@/billing/billingAccess";
 import { getBillingService } from "@/billing/billingService";

--- a/apps/maple-research/frontend/src/components/settings/HistorySettings.tsx
+++ b/apps/maple-research/frontend/src/components/settings/HistorySettings.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useBlocker, useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { Loader2, Trash2 } from "lucide-react";
 import { AlertDestructive } from "@/components/AlertDestructive";
 import { Button } from "@/components/ui/button";

--- a/apps/maple-research/frontend/src/components/settings/PreferencesSettings.tsx
+++ b/apps/maple-research/frontend/src/components/settings/PreferencesSettings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useBlocker } from "@tanstack/react-router";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { RotateCcw } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";

--- a/apps/maple-research/frontend/src/components/settings/SecuritySettings.tsx
+++ b/apps/maple-research/frontend/src/components/settings/SecuritySettings.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link, useBlocker } from "@tanstack/react-router";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/apps/maple-research/frontend/src/components/settings/SettingsLayout.tsx
+++ b/apps/maple-research/frontend/src/components/settings/SettingsLayout.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, Outlet, useLocation, useRouter } from "@tanstack/react-router";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import {
   ArrowLeft,
   BookOpen,

--- a/apps/maple-research/frontend/src/components/settings/api/ApiKeysSettings.tsx
+++ b/apps/maple-research/frontend/src/components/settings/api/ApiKeysSettings.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link, useBlocker } from "@tanstack/react-router";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { AlertCircle, Calendar, KeyRound, Loader2, Plus, Trash2 } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";

--- a/apps/maple-research/frontend/src/components/settings/api/CreateApiKeySettings.tsx
+++ b/apps/maple-research/frontend/src/components/settings/api/CreateApiKeySettings.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useBlocker, useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { AlertCircle, CheckCircle, Copy, Loader2 } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";

--- a/apps/maple-research/frontend/src/components/settings/api/LocalProxySettings.tsx
+++ b/apps/maple-research/frontend/src/components/settings/api/LocalProxySettings.tsx
@@ -1,4 +1,4 @@
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { AlertCircle, Loader2 } from "lucide-react";
 import { ProxyConfigSection } from "@/components/apikeys/ProxyConfigSection";
 import { Alert, AlertDescription } from "@/components/ui/alert";

--- a/apps/maple-research/frontend/src/components/settings/api/useApiKeys.ts
+++ b/apps/maple-research/frontend/src/components/settings/api/useApiKeys.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 
 export type ApiKeySummary = {
   name: string;

--- a/apps/maple-research/frontend/src/components/settings/api/useProxyModels.ts
+++ b/apps/maple-research/frontend/src/components/settings/api/useProxyModels.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { fetchProxyChatModels } from "@/services/proxyModels";
 import type { OpenSecretModel, OpenSecretModelCatalog } from "@/state/LocalStateContextDef";
 

--- a/apps/maple-research/frontend/src/components/settings/team/TeamInviteSettings.tsx
+++ b/apps/maple-research/frontend/src/components/settings/team/TeamInviteSettings.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link, useBlocker } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import {
   AlertCircle,
   ArrowLeft,

--- a/apps/maple-research/frontend/src/components/settings/team/TeamMembersSettings.tsx
+++ b/apps/maple-research/frontend/src/components/settings/team/TeamMembersSettings.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useBlocker } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { AlertCircle, Clock, Crown, Loader2, RotateCw, UserMinus, X } from "lucide-react";
 import { getBillingService } from "@/billing/billingService";
 import { Alert, AlertDescription } from "@/components/ui/alert";

--- a/apps/maple-research/frontend/src/components/settings/team/TeamSettings.tsx
+++ b/apps/maple-research/frontend/src/components/settings/team/TeamSettings.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import { Link, useBlocker } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import {
   AlertCircle,
   AlertTriangle,

--- a/apps/maple-research/frontend/src/components/team/TeamSeatMismatchAlert.tsx
+++ b/apps/maple-research/frontend/src/components/team/TeamSeatMismatchAlert.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { AlertTriangle, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getBillingService } from "@/billing/billingService";

--- a/apps/maple-research/frontend/src/config/openSecretPcrEnvironment.ts
+++ b/apps/maple-research/frontend/src/config/openSecretPcrEnvironment.ts
@@ -1,4 +1,4 @@
-import type { PcrEnvironment } from "@opensecret/react";
+import type { PcrEnvironment } from "@mapleai/sdk";
 
 export function parseOpenSecretPcrEnvironment(value: string | undefined): PcrEnvironment {
   if (value === undefined || value === "production") return "production";

--- a/apps/maple-research/frontend/src/routes/__root.tsx
+++ b/apps/maple-research/frontend/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useRef } from "react";
-import { useOpenSecret } from "@opensecret/react";
-import { OpenSecretContextType } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
+import { OpenSecretContextType } from "@mapleai/sdk";
 import { createRootRouteWithContext, Outlet, useLocation } from "@tanstack/react-router";
 import {
   AuthenticatedHomeContent,

--- a/apps/maple-research/frontend/src/routes/agent.tsx
+++ b/apps/maple-research/frontend/src/routes/agent.tsx
@@ -1,5 +1,5 @@
 import { Navigate, createFileRoute } from "@tanstack/react-router";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { AppEntryPage } from "@/components/AppEntryPage";
 import { useRouteMeta } from "@/utils/routeMeta";
 import { appUrl } from "@/config/domains";

--- a/apps/maple-research/frontend/src/routes/auth.$provider.callback.tsx
+++ b/apps/maple-research/frontend/src/routes/auth.$provider.callback.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate, useRouter, Link } from "@tanstack/react-router";
 import { useEffect, useState, useRef } from "react";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { AlertDestructive } from "@/components/AlertDestructive";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Loader2 } from "lucide-react";

--- a/apps/maple-research/frontend/src/routes/desktop-auth.tsx
+++ b/apps/maple-research/frontend/src/routes/desktop-auth.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Loader2 } from "lucide-react";
 import { AppleAuthProvider } from "@/components/AppleAuthProvider";

--- a/apps/maple-research/frontend/src/routes/index.tsx
+++ b/apps/maple-research/frontend/src/routes/index.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { AppEntryPage } from "@/components/AppEntryPage";
 import { GuestPaymentWarningDialog } from "@/components/GuestPaymentWarningDialog";
 import { PromoDialog, hasSeenPromo, markPromoAsSeen } from "@/components/PromoDialog";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getBillingService } from "@/billing/billingService";
 import { useBillingState } from "@/state/useLocalState";

--- a/apps/maple-research/frontend/src/routes/login.tsx
+++ b/apps/maple-research/frontend/src/routes/login.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate, useRouter } from "@tanstack/react-router";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/apps/maple-research/frontend/src/routes/payment-success.tsx
+++ b/apps/maple-research/frontend/src/routes/payment-success.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Navigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { getBillingService } from "@/billing/billingService";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { Loader2 } from "lucide-react";
 
 export const Route = createFileRoute("/payment-success")({

--- a/apps/maple-research/frontend/src/routes/pricing.tsx
+++ b/apps/maple-research/frontend/src/routes/pricing.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState, useEffect, useCallback, type ReactNode } from "react";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { FullPageMain } from "@/components/FullPageMain";
 import { getBillingService } from "@/billing/billingService";
 import { useQuery } from "@tanstack/react-query";

--- a/apps/maple-research/frontend/src/routes/proof.tsx
+++ b/apps/maple-research/frontend/src/routes/proof.tsx
@@ -17,7 +17,7 @@ import {
   Bot
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { ParsedAttestationView, useOpenSecret } from "@opensecret/react";
+import { ParsedAttestationView, useOpenSecret } from "@mapleai/sdk";
 import { TopNav } from "@/components/TopNav";
 import { FullPageMain } from "@/components/FullPageMain";
 import { MarketingHeader } from "@/components/MarketingHeader";

--- a/apps/maple-research/frontend/src/routes/redeem.tsx
+++ b/apps/maple-research/frontend/src/routes/redeem.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState, useEffect } from "react";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { TopNav } from "@/components/TopNav";
 import { FullPageMain } from "@/components/FullPageMain";
 import { getBillingService } from "@/billing/billingService";

--- a/apps/maple-research/frontend/src/routes/signup.tsx
+++ b/apps/maple-research/frontend/src/routes/signup.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useLocation, useNavigate, useRouter } from "@tanstack/react-router";
-import { useOpenSecret, type LoginResponse } from "@opensecret/react";
+import { useOpenSecret, type LoginResponse } from "@mapleai/sdk";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/apps/maple-research/frontend/src/routes/team.invite.$inviteId.tsx
+++ b/apps/maple-research/frontend/src/routes/team.invite.$inviteId.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { getBillingService } from "@/billing/billingService";
 import { TopNav } from "@/components/TopNav";
 import { FullPageMain } from "@/components/FullPageMain";

--- a/apps/maple-research/frontend/src/routes/verify.$code.tsx
+++ b/apps/maple-research/frontend/src/routes/verify.$code.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate, useRouter } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import { AlertDestructive } from "@/components/AlertDestructive";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Loader2 } from "lucide-react";

--- a/apps/maple-research/frontend/src/services/inferenceCapacityRetry.test.ts
+++ b/apps/maple-research/frontend/src/services/inferenceCapacityRetry.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   findOpenSecretInferenceCapacityError,
   OpenSecretInferenceCapacityError
-} from "@opensecret/react";
+} from "@mapleai/sdk";
 import OpenAI from "openai";
 import { withInferenceCapacityRetry } from "./inferenceCapacityRetry";
 

--- a/apps/maple-research/frontend/src/services/inferenceCapacityRetry.ts
+++ b/apps/maple-research/frontend/src/services/inferenceCapacityRetry.ts
@@ -1,4 +1,4 @@
-import { findOpenSecretInferenceCapacityError } from "@opensecret/react";
+import { findOpenSecretInferenceCapacityError } from "@mapleai/sdk";
 
 async function waitForRetry(delayMs: number, signal: AbortSignal): Promise<void> {
   signal.throwIfAborted();

--- a/apps/maple-research/frontend/src/services/tts/TTSContext.test.tsx
+++ b/apps/maple-research/frontend/src/services/tts/TTSContext.test.tsx
@@ -7,7 +7,7 @@ const aiCustomFetch = mock(async () => {
   throw new Error("Free-plan TTS should not reach the backend");
 });
 
-mock.module("@opensecret/react", () => ({
+mock.module("@mapleai/sdk", () => ({
   useOpenSecret: () => ({
     aiCustomFetch,
     apiUrl: "https://enclave.example"

--- a/apps/maple-research/frontend/src/services/tts/TTSContext.tsx
+++ b/apps/maple-research/frontend/src/services/tts/TTSContext.tsx
@@ -1,4 +1,4 @@
-import { useOpenSecret } from "@opensecret/react";
+import { useOpenSecret } from "@mapleai/sdk";
 import {
   createContext,
   useCallback,

--- a/apps/maple-research/frontend/src/utils/paginatedLists.ts
+++ b/apps/maple-research/frontend/src/utils/paginatedLists.ts
@@ -3,7 +3,7 @@ import type {
   ConversationProjectListItem,
   ConversationsListParams,
   OpenSecretContextType
-} from "@opensecret/react";
+} from "@mapleai/sdk";
 
 const SIDEBAR_PAGE_SIZE = 20;
 

--- a/docs/maple-agent-import.md
+++ b/docs/maple-agent-import.md
@@ -23,9 +23,10 @@ the import merge would discard the preserved upstream ancestry.
 
 ## Integration
 
-- Use the existing local `opensecret` and `maple-proxy` packages. The GPUI SDK
+- Use the local `maple-sdk` and `maple-proxy` packages. The GPUI SDK
   fork is replaced by the canonical catalog API and its boolean capability
-  contract. Package renaming and registry publishing remain separate work.
+  contract. The SDK package is renamed in tree; registry publishing remains
+  separate work.
 - Keep the GPUI component's Cargo/Nix environment and internal `maple-gpui`
   binary name. Root commands, CI, and agent guidance route to the component.
   Linux exposes pure Nix packages; macOS uses the Nix development shell plus

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1456,7 +1456,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "http",
- "opensecret",
+ "maple-sdk",
  "serde",
  "serde_json",
  "tokio",
@@ -1464,6 +1464,41 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "maple-sdk"
+version = "3.6.2"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bytes",
+ "chacha20poly1305",
+ "chrono",
+ "ciborium",
+ "eventsource-stream",
+ "futures",
+ "hex",
+ "hkdf",
+ "http",
+ "p256",
+ "percent-encoding",
+ "pin-project",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "x25519-dalek",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -1634,41 +1669,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "opensecret"
-version = "3.6.2"
-dependencies = [
- "aes-gcm",
- "anyhow",
- "async-stream",
- "async-trait",
- "base64",
- "bytes",
- "chacha20poly1305",
- "chrono",
- "ciborium",
- "eventsource-stream",
- "futures",
- "hex",
- "hkdf",
- "http",
- "p256",
- "percent-encoding",
- "pin-project",
- "reqwest",
- "ring",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "uuid",
- "x25519-dalek",
- "x509-parser",
- "yasna",
-]
 
 [[package]]
 name = "p256"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/main.rs"
 
 [dependencies]
 # OpenSecret SDK
-opensecret = { version = "3.6.2", path = "../sdk/rust" }
+maple-sdk = { version = "3.6.2", path = "../sdk/rust" }
 
 # Web server
 axum = { version = "0.8.4", features = ["http2", "macros"] }

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -54,6 +54,11 @@ maple-proxy = "0.3.2"
 Crates.io publishing remains separate from Maple application releases; the
 example above uses the latest published crate version.
 
+The current source consumes the in-tree `maple-sdk` crate through a versioned
+path dependency. That SDK's registry ownership and first publication are
+pending. Publish the SDK before packaging or publishing a proxy crate that
+depends on its new registry name; local path builds work before publication.
+
 ## ⚙️ Configuration
 
 Set environment variables or use command-line arguments:

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use opensecret::Pcr0Environment;
+use maple_sdk::Pcr0Environment;
 use serde::Serialize;
 use std::{net::SocketAddr, time::Duration};
 

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -2,7 +2,7 @@ mod config;
 mod proxy;
 
 pub use config::Config;
-pub use opensecret::Pcr0Environment;
+pub use maple_sdk::Pcr0Environment;
 use proxy::{health_check, proxy_openai_request, ProxyState};
 
 use axum::{

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use dashmap::DashMap;
 use futures::{future::BoxFuture, Stream, StreamExt};
-use opensecret::{client::OpenSecretResponseBody, OpenSecretClient, Result as OpenSecretResult};
+use maple_sdk::{client::OpenSecretResponseBody, OpenSecretClient, Result as OpenSecretResult};
 use std::{
     collections::HashSet,
     io,
@@ -209,7 +209,7 @@ fn extract_api_key(
 async fn create_client_with_auth(
     backend_url: &str,
     api_key: &str,
-    pcr0_environment: opensecret::Pcr0Environment,
+    pcr0_environment: maple_sdk::Pcr0Environment,
     request_timeout: Duration,
 ) -> Result<OpenSecretClient, ProxyError> {
     let client = OpenSecretClient::new_with_api_key_and_pcr0_environment(
@@ -435,7 +435,7 @@ mod tests {
             host: "127.0.0.1".to_string(),
             port: 0,
             backend_url: "http://localhost:3000".to_string(),
-            pcr0_environment: opensecret::Pcr0Environment::Production,
+            pcr0_environment: maple_sdk::Pcr0Environment::Production,
             default_api_key: None,
             debug: false,
             enable_cors: false,
@@ -495,7 +495,7 @@ mod tests {
         chunks: Vec<Bytes>,
     ) -> http::Response<OpenSecretResponseBody> {
         let body: OpenSecretResponseBody = Box::pin(futures::stream::iter(
-            chunks.into_iter().map(Ok::<_, opensecret::Error>),
+            chunks.into_iter().map(Ok::<_, maple_sdk::Error>),
         ));
         let mut response = http::Response::new(body);
         *response.status_mut() = status;
@@ -798,7 +798,7 @@ mod tests {
 
     #[tokio::test]
     async fn transport_errors_are_safe_bad_gateway_responses() {
-        let transport = Arc::new(MockTransport::new(vec![Err(opensecret::Error::Other(
+        let transport = Arc::new(MockTransport::new(vec![Err(maple_sdk::Error::Other(
             "sensitive transport detail".to_string(),
         ))]));
         let response = mock_app(transport)

--- a/scripts/ci/test_agent_rust_deps.py
+++ b/scripts/ci/test_agent_rust_deps.py
@@ -23,6 +23,14 @@ class AgentRustDependencyTests(unittest.TestCase):
                 for name, manifest in verifier.DEPENDENCIES.items()
             ]}
             verifier.verify(graph, root)
+            legacy = copy.deepcopy(graph)
+            legacy["packages"].append({
+                "name": "opensecret",
+                "source": "registry+https://github.com/rust-lang/crates.io-index",
+                "manifest_path": str(root / "registry" / "opensecret" / "Cargo.toml"),
+            })
+            with self.assertRaisesRegex(ValueError, "legacy opensecret SDK"):
+                verifier.verify(legacy, root)
             for name in verifier.DEPENDENCIES:
                 for alteration in ("duplicate", "missing", "registry", "fork", "other_checkout"):
                     with self.subTest(name=name, alteration=alteration):

--- a/scripts/ci/verify-agent-rust-deps.py
+++ b/scripts/ci/verify-agent-rust-deps.py
@@ -7,10 +7,12 @@ import sys
 
 
 ROOT = Path(__file__).resolve().parents[2]
-DEPENDENCIES = {"opensecret": "sdk/rust/Cargo.toml", "maple-proxy": "proxy/Cargo.toml"}
+DEPENDENCIES = {"maple-sdk": "sdk/rust/Cargo.toml", "maple-proxy": "proxy/Cargo.toml"}
 
 
 def verify(metadata: dict, root: Path = ROOT) -> None:
+    if any(package["name"] == "opensecret" for package in metadata["packages"]):
+        raise ValueError("Agent must not resolve the legacy opensecret SDK alongside maple-sdk")
     for name, relative in DEPENDENCIES.items():
         packages = [package for package in metadata["packages"] if package["name"] == name]
         if len(packages) != 1:
@@ -29,7 +31,7 @@ def main() -> int:
         verify(metadata)
     except (KeyError, ValueError) as error:
         raise SystemExit(str(error)) from None
-    print("Maple Agent resolves exactly one in-tree OpenSecret SDK and proxy crate.")
+    print("Maple Agent resolves exactly one in-tree Maple SDK and proxy crate, with no legacy SDK.")
     return 0
 
 

--- a/scripts/ci/verify-local-rust-deps.sh
+++ b/scripts/ci/verify-local-rust-deps.sh
@@ -12,12 +12,13 @@ cargo metadata \
   --format-version 1 > "${metadata_file}"
 
 jq -e --arg root "${repo_root}" '
-  ([.packages[] | select(.name == "opensecret")] | length) == 1 and
+  ([.packages[] | select(.name == "opensecret")] | length) == 0 and
+  ([.packages[] | select(.name == "maple-sdk")] | length) == 1 and
   ([.packages[] | select(.name == "maple-proxy")] | length) == 1 and
-  ([.packages[] | select(.name == "opensecret")][0].source == null) and
-  ([.packages[] | select(.name == "opensecret")][0].manifest_path == ($root + "/sdk/rust/Cargo.toml")) and
+  ([.packages[] | select(.name == "maple-sdk")][0].source == null) and
+  ([.packages[] | select(.name == "maple-sdk")][0].manifest_path == ($root + "/sdk/rust/Cargo.toml")) and
   ([.packages[] | select(.name == "maple-proxy")][0].source == null) and
   ([.packages[] | select(.name == "maple-proxy")][0].manifest_path == ($root + "/proxy/Cargo.toml"))
 ' "${metadata_file}" > /dev/null
 
-echo "Maple resolves exactly one in-tree OpenSecret SDK and proxy crate."
+echo "Maple resolves exactly one in-tree Maple SDK and proxy crate, with no legacy SDK."

--- a/scripts/prepare-typescript-sdk.sh
+++ b/scripts/prepare-typescript-sdk.sh
@@ -9,6 +9,7 @@ bun --no-env-file install --frozen-lockfile --ignore-scripts
 rm -rf dist
 bun --no-env-file run build
 
-test -f dist/opensecret-react.es.js
-test -f dist/opensecret-react.umd.js
+test -f dist/maple-sdk.es.js
+test -f dist/maple-sdk.umd.cjs
 test -f dist/index.d.ts
+test -f dist/index.d.cts

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,7 +1,7 @@
-# OpenSecret SDKs
+# Maple SDKs
 
 This directory contains the TypeScript/React and Rust clients used by Maple and
-OpenSecret's internal applications. Both clients establish attested,
+internal OpenSecret applications. Both clients establish attested,
 end-to-end encrypted sessions with an OpenSecret backend and expose the API
 surface needed by those applications.
 
@@ -12,10 +12,10 @@ and tests.
 
 ## Repository layout
 
-- `src/` — `@opensecret/react`, including the React providers, encrypted API
+- `src/` — `@mapleai/sdk`, including the React providers, encrypted API
   client, attestation policy, model/conversation APIs, and internal developer
   platform client.
-- `rust/` — the `opensecret` crate used by native clients.
+- `rust/` — the `maple-sdk` crate, imported as `maple_sdk` by native clients.
 - `docs/PLATFORM.md` — internal developer/platform API notes.
 - repository-root `.github/workflows/sdk-*.yml` — path-scoped TypeScript, Rust,
   and supply-chain validation for this directory.
@@ -23,8 +23,21 @@ and tests.
 Maple's frontend consumes this TypeScript package through `file:../../../sdk`.
 Desktop Maple and `proxy/` consume `sdk/rust` through versioned path
 dependencies; iOS and Android exclude those desktop-only Rust consumers.
-Published npm and crates.io packages remain independent compatibility surfaces
-for external users.
+Published npm and crates.io packages remain independently versioned.
+
+## Package identity migration
+
+The new package names are `@mapleai/sdk` and `maple-sdk`. This source change
+retains TypeScript version 3.5.2 and Rust version 3.6.2; first publication and
+registry ownership are separate steps. Until those packages are published,
+develop against the in-tree dependencies above. The registry installation
+examples below describe the new package identities after publication.
+
+The rename preserves the exported API, including `OpenSecretProvider`,
+`useOpenSecret`, `OpenSecretDeveloper` and `OpenSecretClient`. OpenSecret remains
+the backend name. Backend URLs, configuration variables, signed-PCR verification
+and encrypted transport retain their existing contracts. Existing published
+`@opensecret/react` and `opensecret` packages remain available to older consumers.
 
 ## Security model
 
@@ -46,14 +59,14 @@ production paths.
 Install the package:
 
 ```sh
-bun add @opensecret/react
+bun add @mapleai/sdk
 ```
 
 Wrap the application with `OpenSecretProvider` and supply the backend URL and
 client ID:
 
 ```tsx
-import { OpenSecretProvider } from "@opensecret/react";
+import { OpenSecretProvider } from "@mapleai/sdk";
 import type { ReactNode } from "react";
 
 export function AppProviders({ children }: { children: ReactNode }) {
@@ -127,10 +140,11 @@ Add the crate to a Rust application:
 
 ```toml
 [dependencies]
-opensecret = "3"
+maple-sdk = "3.6.2"
 ```
 
-The primary entry point is `OpenSecretClient`. See `rust/README.md` for native
+Import the primary entry point with `use maple_sdk::OpenSecretClient`.
+See `rust/README.md` for native
 client examples and transport details.
 
 Run the Rust validation from the `sdk/` directory:

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -3,13 +3,14 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@opensecret/react",
+      "name": "@mapleai/sdk",
       "dependencies": {
         "@peculiar/x509": "1.14.3",
         "@stablelib/base64": "2.0.1",
         "@stablelib/chacha20poly1305": "2.0.1",
         "@stablelib/random": "2.0.1",
         "cbor2": "1.12.0",
+        "openai": "5.23.2",
         "tweetnacl": "1.0.3",
         "zod": "3.25.76",
       },
@@ -24,7 +25,6 @@
         "eslint": "9.39.5",
         "eslint-plugin-react-hooks": "5.2.0",
         "globals": "15.15.0",
-        "openai": "5.23.2",
         "prettier": "3.9.6",
         "typescript": "5.6.3",
         "typescript-eslint": "8.66.0",

--- a/sdk/docs/PLATFORM.md
+++ b/sdk/docs/PLATFORM.md
@@ -7,7 +7,7 @@ The Developer Platform API allows developers to manage organizations, projects, 
 The `OpenSecretDeveloper` component is the provider for developer-specific platform operations. It requires the URL of the OpenSecret developer API.
 
 ```tsx
-import { OpenSecretDeveloper } from "@opensecret/react";
+import { OpenSecretDeveloper } from "@mapleai/sdk";
 
 function App() {
   return (
@@ -125,7 +125,7 @@ export type OAuthSettings = {
 Before using the developer platform APIs, you need to authenticate. The SDK provides authentication methods through the `useOpenSecretDeveloper` hook:
 
 ```tsx
-import { useOpenSecretDeveloper } from "@opensecret/react";
+import { useOpenSecretDeveloper } from "@mapleai/sdk";
 
 function DeveloperLogin() {
   const dev = useOpenSecretDeveloper();
@@ -229,8 +229,8 @@ changePlatformPassword(currentPassword: string, newPassword: string): Promise<{ 
 The SDK provides methods for managing platform developer passwords, including password reset and password change functionality:
 
 ```tsx
-import { useOpenSecretDeveloper } from "@opensecret/react";
-import { generateSecureSecret, hashSecret } from "@opensecret/react";
+import { useOpenSecretDeveloper } from "@mapleai/sdk";
+import { generateSecureSecret, hashSecret } from "@mapleai/sdk";
 
 function DeveloperPasswordManagement() {
   const dev = useOpenSecretDeveloper();
@@ -312,7 +312,7 @@ if (!dev.auth.loading && dev.auth.developer) {
 The `useOpenSecretDeveloper` hook provides access to all developer platform management APIs. It returns an object with the following properties and methods:
 
 ```tsx
-import { useOpenSecretDeveloper } from "@opensecret/react";
+import { useOpenSecretDeveloper } from "@mapleai/sdk";
 
 function PlatformManagement() {
   const dev = useOpenSecretDeveloper();
@@ -669,7 +669,7 @@ Here's a complete example of how to use the developer platform API:
 
 ```tsx
 import React, { useEffect, useState } from 'react';
-import { OpenSecretDeveloper, useOpenSecretDeveloper } from '@opensecret/react';
+import { OpenSecretDeveloper, useOpenSecretDeveloper } from '@mapleai/sdk';
 
 function DeveloperPortal() {
   const dev = useOpenSecretDeveloper();

--- a/sdk/flake.nix
+++ b/sdk/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "OpenSecret SDK - TypeScript and Rust development environment";
+  description = "Maple SDK - TypeScript and Rust development environment";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -66,7 +66,7 @@
           packages = allInputs;
 
           shellHook = ''
-            echo "OpenSecret SDK Development Environment"
+            echo "Maple SDK Development Environment"
             echo "----------------------------------------"
             echo "TypeScript/Bun tools available"
             echo "Rust toolchain: $(rustc --version)"

--- a/sdk/justfile
+++ b/sdk/justfile
@@ -2,8 +2,8 @@
 publish-npm:
     nix develop --no-update-lock-file -c bun install --frozen-lockfile --ignore-scripts
     nix develop --no-update-lock-file -c bun run build
-    nix develop --no-update-lock-file -c bun pm pack --filename opensecret-react-publish.tgz
-    nix develop --no-update-lock-file -c npm publish ./opensecret-react-publish.tgz --access public
+    nix develop --no-update-lock-file -c bun pm pack --filename maple-sdk-publish.tgz
+    nix develop --no-update-lock-file -c npm publish ./maple-sdk-publish.tgz --access public
 
 # Publish the Rust crate using the committed lockfile.
 publish-cargo:

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,20 +1,31 @@
 {
-  "name": "@opensecret/react",
+  "name": "@mapleai/sdk",
   "version": "3.5.2",
   "packageManager": "bun@1.3.5",
   "license": "MIT",
+  "homepage": "https://github.com/MaplePrivacyLabs/Maple/tree/master/sdk",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MaplePrivacyLabs/Maple.git",
+    "directory": "sdk"
+  },
   "type": "module",
   "files": [
     "dist"
   ],
-  "main": "./dist/opensecret-react.umd.js",
-  "module": "./dist/opensecret-react.es.js",
+  "main": "./dist/maple-sdk.umd.cjs",
+  "module": "./dist/maple-sdk.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/opensecret-react.es.js",
-      "require": "./dist/opensecret-react.umd.js",
-      "types": "./dist/index.d.ts"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/maple-sdk.es.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/maple-sdk.umd.cjs"
+      }
     }
   },
   "scripts": {
@@ -36,6 +47,7 @@
     "@stablelib/chacha20poly1305": "2.0.1",
     "@stablelib/random": "2.0.1",
     "cbor2": "1.12.0",
+    "openai": "5.23.2",
     "tweetnacl": "1.0.3",
     "zod": "3.25.76"
   },
@@ -50,7 +62,6 @@
     "eslint": "9.39.5",
     "eslint-plugin-react-hooks": "5.2.0",
     "globals": "15.15.0",
-    "openai": "5.23.2",
     "prettier": "3.9.6",
     "typescript": "5.6.3",
     "typescript-eslint": "8.66.0",

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1142,6 +1142,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "maple-sdk"
+version = "3.6.2"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bytes",
+ "chacha20poly1305",
+ "chrono",
+ "ciborium",
+ "dotenvy",
+ "eventsource-stream",
+ "futures",
+ "hex",
+ "hkdf",
+ "http",
+ "p256",
+ "percent-encoding",
+ "pin-project",
+ "pretty_assertions",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-test",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "wiremock",
+ "x25519-dalek",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,46 +1293,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "opensecret"
-version = "3.6.2"
-dependencies = [
- "aes-gcm",
- "anyhow",
- "async-stream",
- "async-trait",
- "base64",
- "bytes",
- "chacha20poly1305",
- "chrono",
- "ciborium",
- "dotenvy",
- "eventsource-stream",
- "futures",
- "hex",
- "hkdf",
- "http",
- "p256",
- "percent-encoding",
- "pin-project",
- "pretty_assertions",
- "reqwest",
- "ring",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 2.0.20",
- "tokio",
- "tokio-test",
- "tracing",
- "tracing-subscriber",
- "uuid",
- "wiremock",
- "x25519-dalek",
- "x509-parser",
- "yasna",
-]
 
 [[package]]
 name = "p256"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "opensecret"
+name = "maple-sdk"
 version = "3.6.2"
 edition = "2021"
-authors = ["OpenSecret"]
-description = "Rust SDK for OpenSecret - secure AI API interactions with nitro attestation"
+authors = ["Maple Privacy Labs"]
+description = "Maple Rust SDK for secure AI APIs, encrypted sessions, and Nitro attestation"
 license = "MIT"
-homepage = "https://opensecret.cloud"
+homepage = "https://trymaple.ai"
 repository = "https://github.com/MaplePrivacyLabs/Maple"
-documentation = "https://docs.rs/opensecret"
-keywords = ["opensecret", "ai", "encryption", "nitro", "attestation"]
+documentation = "https://docs.rs/maple-sdk"
+keywords = ["maple", "ai", "encryption", "nitro", "attestation"]
 categories = ["cryptography", "api-bindings", "web-programming"]
 
 [dependencies]

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -1,10 +1,10 @@
-# OpenSecret Rust SDK
+# Maple Rust SDK
 
 This source lives under Maple's `sdk/rust/` directory. Desktop Maple and
 Maple's in-tree `proxy/` consume it through versioned path dependencies, while
 crates.io publishing remains an independent compatibility surface.
 
-Rust SDK for OpenSecret - secure AI API interactions with nitro attestation.
+Maple Rust SDK for the OpenSecret backend: secure AI APIs, encrypted sessions, and Nitro attestation.
 
 ## Features
 
@@ -17,20 +17,26 @@ Rust SDK for OpenSecret - secure AI API interactions with nitro attestation.
 
 ## Installation
 
-Add to your `Cargo.toml`:
+`maple-sdk` is the intended replacement for the `opensecret` crate. Registry
+ownership and first publication are pending; this checkout uses local path
+dependencies. After publication, add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-opensecret = "3.6.2"
+maple-sdk = "3.6.2"
 bytes = "1"
 futures = "0.3"
 http = "1"
 ```
 
+Public Rust types such as `OpenSecretClient` keep their existing names. The
+package and import names change; backend URLs, authentication, and attestation
+behavior remain unchanged.
+
 ## Quick Start
 
 ```rust
-use opensecret::{OpenSecretClient, Pcr0Environment, Pcr0TrustPolicy, Result};
+use maple_sdk::{OpenSecretClient, Pcr0Environment, Pcr0TrustPolicy, Result};
 use uuid::Uuid;
 
 #[tokio::main]
@@ -217,7 +223,7 @@ if let Some(session_id) = client.get_session_id()? {
 The SDK uses a custom `Error` type with detailed error variants:
 
 ```rust
-use opensecret::Error;
+use maple_sdk::Error;
 
 match client.login(email, password, client_id).await {
     Ok(response) => println!("Success!"),

--- a/sdk/rust/examples/api_usage.rs
+++ b/sdk/rust/examples/api_usage.rs
@@ -1,4 +1,4 @@
-use opensecret::{KeyOptions, OpenSecretClient, Result, SigningAlgorithm};
+use maple_sdk::{KeyOptions, OpenSecretClient, Result, SigningAlgorithm};
 use uuid::Uuid;
 
 #[tokio::main]

--- a/sdk/rust/examples/auth_example.rs
+++ b/sdk/rust/examples/auth_example.rs
@@ -1,4 +1,4 @@
-use opensecret::{OpenSecretClient, Result};
+use maple_sdk::{OpenSecretClient, Result};
 use uuid::Uuid;
 
 #[tokio::main]

--- a/sdk/rust/tests/account_management.rs
+++ b/sdk/rust/tests/account_management.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use opensecret::{OpenSecretClient, Result};
+use maple_sdk::{OpenSecretClient, Result};
 use std::env;
 use uuid::Uuid;
 

--- a/sdk/rust/tests/agent_integration.rs
+++ b/sdk/rust/tests/agent_integration.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use futures::StreamExt;
-use opensecret::{
+use maple_sdk::{
     AgentItemsListParams, AgentSseEvent, ConversationItem, CreateSubagentRequest,
     ListSubagentsParams, OpenSecretClient, Result,
 };
@@ -51,7 +51,7 @@ async fn setup_authenticated_client() -> Result<OpenSecretClient> {
     Ok(client)
 }
 
-async fn create_test_subagent(client: &OpenSecretClient) -> Result<opensecret::SubagentResponse> {
+async fn create_test_subagent(client: &OpenSecretClient) -> Result<maple_sdk::SubagentResponse> {
     let suffix = Uuid::new_v4();
 
     client

--- a/sdk/rust/tests/ai_integration.rs
+++ b/sdk/rust/tests/ai_integration.rs
@@ -2,7 +2,7 @@ mod common;
 
 use base64::{engine::general_purpose, Engine as _};
 use futures::StreamExt;
-use opensecret::{
+use maple_sdk::{
     ChatCompletionRequest, ChatMessage, EmbeddingInput, EmbeddingRequest, Error, Function,
     OpenSecretClient, Result, Tool,
 };

--- a/sdk/rust/tests/api_integration.rs
+++ b/sdk/rust/tests/api_integration.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use opensecret::{KeyOptions, Result, SigningAlgorithm};
+use maple_sdk::{KeyOptions, Result, SigningAlgorithm};
 use uuid::Uuid;
 
 #[tokio::test]

--- a/sdk/rust/tests/api_keys.rs
+++ b/sdk/rust/tests/api_keys.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use opensecret::{Error, OpenSecretClient, Result};
+use maple_sdk::{Error, OpenSecretClient, Result};
 use std::env;
 use uuid::Uuid;
 
@@ -135,7 +135,7 @@ async fn test_streaming_chat_with_api_key() -> Result<()> {
     }
 
     use futures::StreamExt;
-    use opensecret::{ChatCompletionRequest, ChatMessage};
+    use maple_sdk::{ChatCompletionRequest, ChatMessage};
 
     let (api_url, email, password, client_id) = get_test_config();
 

--- a/sdk/rust/tests/attestation.rs
+++ b/sdk/rust/tests/attestation.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use opensecret::{Error, OpenSecretClient, Pcr0Environment, Result};
+use maple_sdk::{Error, OpenSecretClient, Pcr0Environment, Result};
 use std::env;
 
 #[tokio::test]

--- a/sdk/rust/tests/auth_integration.rs
+++ b/sdk/rust/tests/auth_integration.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use opensecret::Result;
+use maple_sdk::Result;
 use uuid::Uuid;
 
 #[tokio::test]

--- a/sdk/rust/tests/bip85_integration.rs
+++ b/sdk/rust/tests/bip85_integration.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use opensecret::{KeyOptions, Result, SigningAlgorithm};
+use maple_sdk::{KeyOptions, Result, SigningAlgorithm};
 use uuid::Uuid;
 
 // BIP-85 test constants (matching TypeScript tests)

--- a/sdk/rust/tests/common/mod.rs
+++ b/sdk/rust/tests/common/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use opensecret::{Error, OpenSecretClient, Pcr0Environment, Result};
+use maple_sdk::{Error, OpenSecretClient, Pcr0Environment, Result};
 use std::env::{self, VarError};
 
 const PCR_ENVIRONMENT_VARIABLE: &str = "VITE_OPEN_SECRET_PCR_ENVIRONMENT";

--- a/sdk/rust/tests/crypto.rs
+++ b/sdk/rust/tests/crypto.rs
@@ -1,8 +1,8 @@
 use base64::Engine;
-use opensecret::crypto::{
+use maple_sdk::crypto::{
     decrypt_message, decrypt_session_key, derive_shared_secret, encrypt_message, generate_key_pair,
 };
-use opensecret::Result;
+use maple_sdk::Result;
 
 #[test]
 fn test_key_generation() {

--- a/sdk/rust/tests/integration.rs
+++ b/sdk/rust/tests/integration.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use opensecret::Result;
+use maple_sdk::Result;
 use std::env;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};

--- a/sdk/rust/tests/pcr_environment.rs
+++ b/sdk/rust/tests/pcr_environment.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::parse_pcr0_environment;
-use opensecret::Pcr0Environment;
+use maple_sdk::Pcr0Environment;
 
 #[test]
 fn pcr_environment_defaults_to_production() {

--- a/sdk/rust/tests/session.rs
+++ b/sdk/rust/tests/session.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use opensecret::Result;
+use maple_sdk::Result;
 use std::env;
 
 #[tokio::test]
@@ -35,7 +35,7 @@ async fn test_session_establishment() -> Result<()> {
 
 #[tokio::test]
 async fn test_session_key_derivation() -> Result<()> {
-    use opensecret::crypto::{derive_shared_secret, generate_key_pair};
+    use maple_sdk::crypto::{derive_shared_secret, generate_key_pair};
 
     // Test key derivation works correctly
     let client_keypair = generate_key_pair();

--- a/sdk/rust/tests/web_integration.rs
+++ b/sdk/rust/tests/web_integration.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use opensecret::{OpenSecretClient, Result, WebExtractRequest, WebSearchRequest};
+use maple_sdk::{OpenSecretClient, Result, WebExtractRequest, WebSearchRequest};
 use uuid::Uuid;
 
 async fn authenticated_client() -> Result<OpenSecretClient> {

--- a/sdk/vite.config.ts
+++ b/sdk/vite.config.ts
@@ -33,7 +33,14 @@ export default defineConfig({
     derPlugin(),
     dts({
       rollupTypes: true,
-      tsconfigPath: "tsconfig.build.json"
+      tsconfigPath: "tsconfig.build.json",
+      afterBuild() {
+        // NodeNext requires a CommonJS declaration file for the require export.
+        fs.copyFileSync(
+          path.resolve(__dirname, "dist/index.d.ts"),
+          path.resolve(__dirname, "dist/index.d.cts")
+        );
+      }
     })
   ],
   // Add .der to assetsInclude to ensure it's processed
@@ -47,8 +54,8 @@ export default defineConfig({
   build: {
     lib: {
       entry: path.resolve(__dirname, "src/lib/index.ts"),
-      name: "OpenSecretReact",
-      fileName: (format) => `opensecret-react.${format}.js`
+      name: "MapleSDK",
+      fileName: (format) => `maple-sdk.${format}.${format === "umd" ? "cjs" : "js"}`
     },
     rollupOptions: {
       // Externalize React along with its internals


### PR DESCRIPTION
The monorepo SDKs now use `@mapleai/sdk` for TypeScript/React and `maple-sdk` (`maple_sdk` imports) for Rust. Research, Agent and the proxy consume the renamed in-tree packages, with matching package metadata, examples, build artifacts and dependency checks.

**This PR changes source package identities and in-tree consumers; it does not publish either SDK.** Registry bootstrap and protected publishing workflows are a separate next step.

The existing SDK versions remain 3.5.2 (TypeScript) and 3.6.2 (Rust). Exported APIs such as `OpenSecretProvider` and `OpenSecretClient`, backend identity, configuration variables, protocol headers, encrypted transport and signed-PCR verification remain unchanged.

Fresh tarball consumers exposed two inherited packaging defects. The CommonJS entry now uses `.cjs` with a matching `.d.cts` declaration and conditional type exports. The existing pinned OpenAI dependency moves from development to package dependencies because public `Model` declarations import its types. These corrections preserve the exported API.

Local validation: TypeScript SDK 123 tests pass (3 credential-dependent skips); the seven-file package passes ESM, CommonJS, UMD, strict Bundler and strict NodeNext consumer checks. All 45 runtime exports and public declarations match the original package. Research's full frontend gate passes 818 tests. Rust SDK strict Clippy, 85 tests, rustdoc and extracted 34-file crate build pass. Proxy strict Clippy, 27 tests, rustdoc and Machete pass; Research native tests pass 415 tests (2 ignored). Both consumer dependency verifiers and all nine local root flake checks pass. Independent source/integration review found no actionable issue.

The complete normal commit hook passes, including all 818 frontend and 415 native Research tests (2 existing ignores), with two Rust test workers to reduce local VM contention. Canonical Research formatting and strict Clippy pass on its actual pinned 1.94.1 toolchain; the extra all-target Clippy run reports eight existing test-only diagnostics in unchanged code. SDK and proxy formatting/strict Clippy also pass with their actual pinned 1.89.0 tools.

Local Cargo subcommand lookup initially selected rustup's installed toolchain; corrected checks use process-local `RUSTUP_TOOLCHAIN` pointing to each Nix toolchain, without global configuration changes. Agent's warning-denied workspace build, 725 workspace tests and 30 headless tests pass (755 total, with 3 existing ignores); formatting and all four strict Clippy modes also pass on its actual pinned 1.98.0 toolchain. Proxy crates.io packaging requires the new SDK to be published; local path builds are the validation available in this source-only round.

