### PR TITLE
Let clients adopt published SDK versions independently

### DIFF
--- a/.agents/skills/change-opensecret-api/SKILL.md
+++ b/.agents/skills/change-opensecret-api/SKILL.md
@@ -104,11 +104,12 @@ not one shared wire-field edit. Trace request construction, provider handoff,
 persistence, and usage in each affected path.
 
 Use the SDK source and application dependency resolutions recorded by the
-selected Maple revision. `apps/maple-research/frontend/package.json` is
-authoritative for the browser client's in-tree `file:../../../sdk` dependency.
-Research desktop, the proxy, and the GPUI prototype consume `sdk/rust` through
-versioned path dependencies in their component `Cargo.toml` files. Update SDK
-types, custom-fetch adaptation, native
+selected Maple revision. The frontend's `package.json` and `bun.lock`, and each
+Rust consumer's Cargo manifest and lockfile, select a published SDK or local
+source. Follow the [SDK consumer version policy](../../../docs/sdk-publishing.md#consumer-version-policy).
+Validate SDK source changes separately from consumers pinned to a published
+version; update only the consumers intended to adopt the changed contract.
+Update SDK types, custom-fetch adaptation, native
 transport allowlists, call sites, mocks, and fixtures only where the contract
 reaches them. Test old-client/new-server and new-client/old-server behavior.
 Prefer server-first rollout for compatible additions; use an explicit

--- a/.agents/skills/develop-maple-agent/SKILL.md
+++ b/.agents/skills/develop-maple-agent/SKILL.md
@@ -12,9 +12,12 @@ identify an arbitrary running development instance.
 
 `app/src/backend.rs` adapts the transport-neutral runtime under
 `crates/maple-agent/` to GPUI. Keep window/UI concerns in `app`, and shared
-account/session/tool policy in the runtime. The runtime consumes the existing
-local `maple-sdk` and `maple-proxy` packages; registry publication is separate
-work. Research's Tauri runtime remains independently owned.
+account/session/tool policy in the runtime. The runtime consumes the in-tree
+`maple-proxy` library and independently selects `maple-sdk` in the workspace
+manifest and lockfile. Follow the [SDK consumer version policy](../../../docs/sdk-publishing.md#consumer-version-policy):
+prefer a published pin and allow local links during active development. Keep
+the runtime and embedded proxy on one SDK source/version. Research's Tauri
+runtime remains independently owned.
 
 ## Build with the component environment
 
@@ -33,9 +36,10 @@ build and performance evidence. Root `just agent-check`, `agent-build`, and
 --no-update-lock-file` additionally validates workflow selection and security
 contracts when CI, Nix, or routing changes.
 
-Agent has its own Cargo and Nix lockfiles. Shared Rust SDK/proxy runtime
-changes must select Agent as well as the Research consumer; component-only
-changes must not unnecessarily select Research packaging. Maintain the root
+Agent has its own Cargo and Nix lockfiles. CI conservatively selects Agent for
+shared Rust SDK/proxy runtime changes even when its SDK is registry-pinned;
+passing that build does not validate unpublished SDK source. Component-only
+changes should not unnecessarily select Research packaging. Maintain the root
 selectors, their tests, and `.github/workflows/agent-ci.yml` together.
 
 Linux Nix packages use a pure source fileset rooted at the monorepo, including

--- a/.agents/skills/develop-maple-proxy/SKILL.md
+++ b/.agents/skills/develop-maple-proxy/SKILL.md
@@ -14,13 +14,19 @@ The source is part of Maple but keeps distinct public package and runtime
 boundaries:
 
 - `proxy/` builds the `maple-proxy` crate and binary.
-- `proxy/Cargo.toml` consumes the in-tree OpenSecret Rust SDK at `../sdk/rust`
-  with a registry version retained for Cargo publishing.
-- desktop Maple consumes `../../proxy` and `../../sdk/rust` from
-  `apps/maple-research/frontend/src-tauri/Cargo.toml`; iOS and Android do not compile the proxy.
+- `proxy/Cargo.toml` uses a compatible `maple-sdk` registry requirement;
+  `proxy/Cargo.lock` selects the standalone binary's version. Local SDK links
+  are also supported during active development.
+- Research desktop and Maple Agent consume the in-tree proxy library and
+  choose their SDK versions independently in their own Cargo manifests/locks.
+  iOS and Android do not compile Research's proxy.
 - `apps/maple-research/frontend/src-tauri/src/proxy.rs` owns Maple's account-scoped listener,
   configuration, key storage, and lifecycle around the library. Do not move
   that application behavior into the reusable crate incidentally.
+
+Follow the [SDK consumer version policy](../../../docs/sdk-publishing.md#consumer-version-policy).
+Keep the embedded proxy and its host on the same SDK source/version; avoid
+exact-pinning the reusable library in a way that forces all hosts to upgrade.
 
 Do not commit, push, open a PR, publish, tag, release, or change live
 infrastructure unless the user authorizes that action.
@@ -40,8 +46,8 @@ nix develop --no-update-lock-file ./proxy -c bash -lc '
 '
 ```
 
-For Rust SDK or dependency-wiring changes, also prove the application resolves
-one local SDK and one local proxy:
+For Rust SDK or dependency-wiring changes, also prove Research resolves one
+SDK from its selected source and the in-tree proxy:
 
 ```sh
 nix develop --no-update-lock-file .#ci -c \
@@ -52,8 +58,10 @@ Root workflows own proxy Rust, daily supply-chain, non-publishing container,
 and native-release rehearsal checks. `proxy/src/**`, `proxy/Cargo.toml`, and
 unknown proxy build inputs are desktop application inputs; tests, examples,
 docs, the standalone lockfile, and container-only files do not by themselves
-route expensive Maple app builds. `sdk/rust` runtime changes affect both proxy
-checks and desktop Maple. When a new input changes either graph, update
+route expensive Maple app builds. `sdk/rust` runtime changes conservatively
+select proxy checks and desktop Maple even with a published SDK pin; verify
+the selected source when testing an SDK edit. When a new input changes either
+graph, update
 `scripts/ci/change_detection.py`, its table-driven tests, and workflow paths in
 the same change.
 

--- a/.agents/skills/develop-maple/SKILL.md
+++ b/.agents/skills/develop-maple/SKILL.md
@@ -43,6 +43,10 @@ just install
 
 The flake pins Bun, Rust, and platform tooling. Use Bun for frontend dependencies; do not create npm, Yarn, or pnpm lockfiles.
 
+Follow the [SDK consumer version policy](../../../docs/sdk-publishing.md#consumer-version-policy).
+Prefer published pins; use local SDK links when developing across that boundary,
+and update only the consumers intended to adopt a new SDK version.
+
 Configure a local API without committing secrets:
 
 ```bash

--- a/.agents/skills/develop-opensecret-sdk/SKILL.md
+++ b/.agents/skills/develop-opensecret-sdk/SKILL.md
@@ -16,9 +16,15 @@ package boundaries remain independently versioned and publishable:
 - `rust/` builds the `maple-sdk` crate (imported as `maple_sdk`) for native consumers.
 - `apps/maple-research/frontend/package.json` is authoritative for whether Maple's browser client
   consumes a published TypeScript version or the in-tree `file:../../../sdk` package.
-- desktop Maple and `proxy/` consume the in-tree Rust crate through versioned
-  path dependencies. iOS and Android do not compile those desktop-only
-  consumers.
+- Research desktop, Maple Agent, and `proxy/` select their Rust SDK through
+  their own manifests and lockfiles. iOS and Android do not compile Research's
+  desktop-only SDK/proxy consumers.
+
+Follow the [consumer version policy](../../../docs/sdk-publishing.md#consumer-version-policy).
+Prefer published pins without upgrading unrelated consumers. Local links are
+allowed during active development, including on `master`; a registry-pinned
+client build does not exercise an SDK source edit. Test an affected consumer
+with the local SDK when that integration is part of the change.
 
 Do not commit, push, open a PR, publish, or alter Maple's application dependency
 wiring unless the user authorizes that action.
@@ -89,8 +95,8 @@ cargo package --locked --manifest-path rust/Cargo.toml
 
 These commands validate package contents; they do not publish them. For Rust
 SDK changes, also run the root `scripts/ci/verify-local-rust-deps.sh` check and
-the applicable desktop/proxy validation before claiming Maple consumes the
-result.
+the applicable desktop/proxy validation. Check its selected SDK source before
+claiming Maple consumes the result.
 
 ## Publishing boundary
 

--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -112,19 +112,34 @@ newer version and unused tag, and successful required workflows for the exact
 commit. Stop on any failure; correct it through the normal reviewed process.
 Never overwrite or move a release tag.
 
-Record the proxy version and whether proxy or Rust SDK runtime inputs changed
-since `previous_tag`:
+Review the [SDK consumer version policy](../../../docs/sdk-publishing.md#consumer-version-policy)
+for the clients being released. Record the frontend's selected SDK from its
+manifest/lockfile and each Rust consumer's resolved version/source using the
+policy's `cargo metadata --locked` command. Local links are allowed. If those
+clients will ship unpublished SDK changes, recommend publishing the SDK and
+pinning those consumers first; an intentional local-source release can proceed
+with the exact monorepo commit recorded. Unrelated SDK source changes do not
+require a pinned client to upgrade, and this preference adds no release gate.
+
+Record the proxy version and inspect its own runtime inputs since `previous_tag`:
 
 ```bash
 proxy_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' proxy/Cargo.toml | head -n 1)"
-git diff --name-only "$previous_tag".."$head_sha" -- proxy sdk/rust
+git diff --name-only "$previous_tag".."$head_sha" -- proxy
 printf 'proxy_version=%s\n' "$proxy_version"
 ```
 
-If runtime inputs changed without a proxy version change, stop and make the
-version decision explicit before publishing. A normal Maple Release always
-builds the checked-in proxy version, but that does not implicitly authorize a
-crates.io or GHCR publish.
+Inspect the proxy's manifest and lockfile at both revisions. Include changes
+under `sdk/rust` in its runtime comparison when either revision uses that local
+SDK. With registry dependencies at both revisions, compare the selected SDK
+versions/checksums in `proxy/Cargo.lock`; unrelated `sdk/rust` edits are not
+proxy runtime changes. The embedding app's SDK selection is separate from the
+standalone proxy's lockfile.
+
+If consumed runtime inputs changed without a proxy version change, stop and
+make the version decision explicit before publishing. A normal Maple Release
+always builds the checked-in proxy version, but that does not implicitly
+authorize a crates.io or GHCR publish.
 
 Preview GitHub's generated notes:
 

--- a/.agents/skills/review-maple-security/SKILL.md
+++ b/.agents/skills/review-maple-security/SKILL.md
@@ -289,10 +289,12 @@ Preserve the OpenSecret SDK's encrypted and attested transport. Do not replace `
 
 Review development and production enclave URLs and PCR/attestation allowlists together. Reject an endpoint that is not HTTPS unless it is an explicit loopback development address. Reject URL credentials and unexpected paths, queries, or fragments at the native authority boundary. Treat source-configured PCR values as policy, not proof that a live enclave currently matches; perform live attestation before making deployment claims.
 
-The SDK source is in this repository. The browser uses `file:../../../sdk`, while
-desktop Maple and `proxy/` use versioned path dependencies on `sdk/rust`.
-Review source changes and resolved application dependencies as distinct
-boundaries, and verify the local Cargo graph before claiming coverage. Do not assume
+The SDK source is in this repository, but each consumer selects a published
+version or local source through its manifest and lockfile. Follow the
+[SDK consumer version policy](../../../docs/sdk-publishing.md#consumer-version-policy).
+Review SDK source changes and resolved application dependencies as distinct
+boundaries: a registry-pinned client does not exercise unpublished SDK edits.
+Verify the selected source and Cargo graph before claiming coverage. Do not assume
 the browser and native SDKs have identical features, request schemas, refresh
 behavior, attestation behavior, or error handling. For an OpenSecret API
 contract change, validate both clients. Keep decrypted upstream errors and

--- a/.agents/skills/review-opensecret-security/SKILL.md
+++ b/.agents/skills/review-opensecret-security/SKILL.md
@@ -109,9 +109,10 @@ Apply these OpenSecret-specific invariants:
   rollback, and access to the owning key; ordinary startup lacks user keys.
 - Shared protocol changes require coordinated review of the monorepo-root
   `sdk/` source and the dependency actually resolved by each affected Maple
-  application path. Treat `apps/maple-research/frontend/package.json` as
-  authoritative for the TypeScript client; Research desktop, the proxy, and
-  the GPUI prototype consume `sdk/rust` through versioned path dependencies.
+  application path. Its manifest and lockfile select a published SDK or local
+  source; do not treat in-tree SDK validation as proof for a consumer pinned
+  to different source. Follow the [SDK consumer version policy](../../../docs/sdk-publishing.md#consumer-version-policy)
+  when reviewing the selected versions and compatibility boundaries.
 
 Use `$change-opensecret-api` or `$change-opensecret-provider` for the detailed
 contract procedure rather than duplicating it here.

--- a/.agents/skills/validate-maple/SKILL.md
+++ b/.agents/skills/validate-maple/SKILL.md
@@ -42,12 +42,13 @@ Use for pure React, TypeScript, CSS, state, and browser behavior with no native 
 SDK work under `sdk/` has its own component checks. Load
 `$develop-opensecret-sdk`, run the applicable TypeScript or Rust SDK checks,
 and add the in-tree OpenSecret integration when the public protocol or
-backend compatibility changes. Maple's frontend consumes `file:../../../sdk`;
-desktop Maple and `proxy/` consume `sdk/rust` through local path dependencies.
-Rust SDK runtime changes therefore require proxy checks and desktop Maple
-coverage, while SDK tests/docs/examples and standalone lockfile changes remain
-independent. Do not run unrelated mobile packaging for desktop-only Rust SDK
-or proxy inputs.
+backend compatibility changes. Follow the [SDK consumer version policy](../../../docs/sdk-publishing.md#consumer-version-policy)
+and inspect the consumer's manifest/lockfile: a published pin and a local link
+exercise different SDK source. CI conservatively selects proxy and desktop
+checks for Rust SDK runtime changes; add local-source consumer coverage when
+claiming an unpublished SDK edit works in that client. SDK tests/docs/examples
+and standalone lockfile changes remain independent. Do not run unrelated mobile
+packaging for desktop-only Rust SDK or proxy inputs.
 
 Proxy work under `proxy/` likewise has component and application boundaries.
 Load `$develop-maple-proxy`. Proxy or Rust SDK runtime inputs route to desktop
@@ -153,7 +154,7 @@ nix develop --no-update-lock-file .#ci -c ./scripts/ci/rust.sh
 
 The lint recipe runs `cargo fmt --check` and Clippy with warnings denied. The CI script provisions Linux ONNX Runtime when needed and runs `cargo test --all-targets --locked`. Neither command launches Maple.
 
-### Proxy checks and local dependency graph
+### Proxy checks and selected dependency graph
 
 Run the proxy's CI-equivalent component checks through its pinned shell:
 
@@ -168,8 +169,8 @@ nix develop --no-update-lock-file ./proxy -c bash -lc '
 '
 ```
 
-For proxy dependency-wiring or Rust SDK runtime changes, also prove the root
-application resolves the intended in-tree crates:
+For proxy dependency-wiring or Rust SDK runtime changes, also prove Research
+resolves one SDK from its selected source and the in-tree proxy:
 
 ```bash
 nix develop --no-update-lock-file .#ci -c \

--- a/.github/workflows/proxy-publish.yml
+++ b/.github/workflows/proxy-publish.yml
@@ -145,14 +145,8 @@ jobs:
 
           if [ -n "${previous_proxy_version}" ]; then
             set +e
-            git diff --quiet "${previous_sha}" "${release_sha}" -- \
-                proxy/Dockerfile \
-                proxy/Cargo.toml \
-                proxy/Cargo.lock \
-                proxy/src \
-                sdk/rust/Cargo.toml \
-                sdk/rust/src \
-                sdk/rust/assets
+            python3 -I scripts/ci/proxy_runtime_diff.py \
+              "${previous_sha}" "${release_sha}"
             runtime_diff_status=$?
             set -e
             case "${runtime_diff_status}" in
@@ -438,14 +432,8 @@ jobs:
             local from_sha="$1"
             local diff_status
             set +e
-            git diff --quiet "${from_sha}" "${RELEASE_SHA}" -- \
-              proxy/Dockerfile \
-              proxy/Cargo.toml \
-              proxy/Cargo.lock \
-              proxy/src \
-              sdk/rust/Cargo.toml \
-              sdk/rust/src \
-              sdk/rust/assets
+            python3 -I scripts/ci/proxy_runtime_diff.py \
+              "${from_sha}" "${RELEASE_SHA}"
             diff_status=$?
             set -e
             case "${diff_status}" in

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -17,6 +17,8 @@ on:
       - "scripts/ci/_common.sh"
       - "scripts/ci/rust.sh"
       - "scripts/ci/verify-local-rust-deps.sh"
+      - "scripts/ci/verify-agent-rust-deps.py"
+      - "scripts/ci/test_agent_rust_deps.py"
       - "flake.nix"
       - "flake.lock"
   pull_request:
@@ -32,6 +34,8 @@ on:
       - "scripts/ci/_common.sh"
       - "scripts/ci/rust.sh"
       - "scripts/ci/verify-local-rust-deps.sh"
+      - "scripts/ci/verify-agent-rust-deps.py"
+      - "scripts/ci/test_agent_rust_deps.py"
       - "flake.nix"
       - "flake.lock"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,11 @@ current source and tests take precedence over historical design documents.
   `justfile`, and `repo.meta.json`: shared documentation, tooling, CI, and
   repository identity. Keep active workflows and discoverable skills at root.
 
+For SDK consumption, follow the [consumer version policy](docs/sdk-publishing.md#consumer-version-policy):
+prefer independently pinned published versions, allow local links during active
+development, and review the actual SDK source before a client release. SDK
+publication and upgrading a consumer are separate decisions.
+
 The backend import does not change TEE deployment or introduce EIF publication
 through GitHub Actions. Preserve the manual signed-PCR compatibility procedure
 in [the backend guide](services/opensecret/docs/pcr-compatibility.md) and the
@@ -87,9 +92,10 @@ Run `nix flake check --no-update-lock-file` for flake, workflow, CI-script, or
 release-configuration changes, plus the affected component checks. The
 pre-commit hook is useful but does not establish full CI parity.
 
-`scripts/ci/change_detection.py` routes expensive app packaging. TypeScript SDK
-runtime inputs affect Research frontend builds; Rust SDK and proxy runtime
-inputs affect desktop builds. Tests, docs, container-only inputs, and standalone
+`scripts/ci/change_detection.py` routes expensive app packaging. It conservatively
+selects Research frontend builds for TypeScript SDK runtime inputs and desktop
+builds for Rust SDK and proxy runtime inputs, including when a consumer uses a
+published SDK pin. Tests, docs, container-only inputs, and standalone
 component lockfiles retain their independent lanes. Update the classifier and
 its table-driven tests when the dependency graph or component layout changes.
 The backend has its own root `opensecret-ci.yml` workflow and change selector;

--- a/apps/maple-agent/Cargo.lock
+++ b/apps/maple-agent/Cargo.lock
@@ -5912,6 +5912,8 @@ dependencies = [
 [[package]]
 name = "maple-sdk"
 version = "3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9efa6ceaaddf0d1ff4d88448eacd48f3ebd6900a8c597d3b729b334750a5b4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/maple-agent/Cargo.toml
+++ b/apps/maple-agent/Cargo.toml
@@ -20,7 +20,7 @@ once_cell = "1.18.0"
 http = "1"
 reqwest = { version = "0.13", features = ["stream"] }
 # Shared monorepo crates retain their independent package names and versions.
-maple-sdk = { version = "3.6.2", path = "../../sdk/rust" }
+maple-sdk = "=3.6.2"
 maple-proxy = { version = "0.3.4", path = "../../proxy" }
 
 [profile.dev]

--- a/apps/maple-research/AGENTS.md
+++ b/apps/maple-research/AGENTS.md
@@ -48,18 +48,20 @@ OpenSecret is its required backend. Keep these runtime paths distinct:
 - Local proxy: a separate user-facing OpenAI-compatible relay. Research chat
   and Agent Mode do not internally route through it.
 
-The OpenSecret SDK source lives under `sdk/`. The browser client consumes the
-in-tree `file:../../../sdk` package, and the desktop Tauri app plus proxy consume the
-in-tree `sdk/rust` crate. Do not assume the TypeScript and Rust SDKs have
-identical transports, retries, or API coverage. A backend contract change that
-Maple consumes needs compatibility checks for every affected client path.
+The OpenSecret SDK source lives under `sdk/`. Research independently selects
+published TypeScript and Rust versions in its manifests and lockfiles; local
+`file:`/Cargo links are supported for active development. Follow the
+[SDK consumer version policy](../../docs/sdk-publishing.md#consumer-version-policy).
+Do not assume the TypeScript and Rust SDKs have identical transports, retries,
+or API coverage. A backend contract change that Maple consumes needs compatibility
+checks for every affected client path.
 
 The Maple Proxy source lives under `proxy/`. From the repository root,
 run its Rust commands through
 `nix develop --no-update-lock-file ./proxy -c bash -lc 'cd proxy && ...'`;
-root path-scoped workflows own proxy CI. Proxy and Rust SDK runtime changes are
-desktop application build inputs; container, test, documentation, and
-standalone lockfile changes remain independent.
+root path-scoped workflows own proxy CI. Proxy and Rust SDK runtime changes
+conservatively select desktop builds, including when the SDK is registry-pinned;
+container, test, documentation, and standalone lockfile changes remain independent.
 
 ## Code ownership and placement
 

--- a/apps/maple-research/frontend/bun.lock
+++ b/apps/maple-research/frontend/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "maple",
       "dependencies": {
-        "@mapleai/sdk": "file:../../../sdk",
+        "@mapleai/sdk": "3.5.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -234,17 +234,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mapleai/sdk": ["@mapleai/sdk@file:../../../sdk", { "dependencies": { "@peculiar/x509": "1.14.3", "@stablelib/base64": "2.0.1", "@stablelib/chacha20poly1305": "2.0.1", "@stablelib/random": "2.0.1", "cbor2": "1.12.0", "openai": "5.23.2", "tweetnacl": "1.0.3", "zod": "3.25.76" }, "devDependencies": { "@eslint/js": "9.39.5", "@noble/curves": "1.9.7", "@noble/hashes": "1.8.0", "@types/bun": "1.1.13", "@types/react": "19.2.18", "@vitejs/plugin-react": "4.7.0", "ajv": "8.20.0", "eslint": "9.39.5", "eslint-plugin-react-hooks": "5.2.0", "globals": "15.15.0", "prettier": "3.9.6", "typescript": "5.6.3", "typescript-eslint": "8.66.0", "vite": "6.4.3", "vite-plugin-dts": "4.5.4" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }],
-
-    "@microsoft/api-extractor": ["@microsoft/api-extractor@7.58.12", "", { "dependencies": { "@microsoft/api-extractor-model": "7.33.10", "@microsoft/tsdoc": "~0.16.0", "@microsoft/tsdoc-config": "~0.18.1", "@rushstack/node-core-library": "5.23.3", "@rushstack/rig-package": "0.7.3", "@rushstack/terminal": "0.24.2", "@rushstack/ts-command-line": "5.3.12", "diff": "~8.0.2", "minimatch": "10.2.3", "resolve": "~1.22.1", "semver": "~7.7.4", "source-map": "~0.6.1", "typescript": "5.9.3" }, "bin": { "api-extractor": "bin/api-extractor" } }, "sha512-VNpgC/1LaroLbn+UKmwDYspq+9r3EHyj4vJ3qUy/g8vB0rKt+1Wgs7WFj/JGpgxhG8SNyXs1XwYwe7nqkk8IDg=="],
-
-    "@microsoft/api-extractor-model": ["@microsoft/api-extractor-model@7.33.10", "", { "dependencies": { "@microsoft/tsdoc": "~0.16.0", "@microsoft/tsdoc-config": "~0.18.1", "@rushstack/node-core-library": "5.23.3" } }, "sha512-uPUK17xGxeQ3av6TN7awp+dTTSTvx8fZC0XFL1gyt7hFapYuxND3XLXH8vkmI7UjfW92oogzFAFqHSifmJROaw=="],
-
-    "@microsoft/tsdoc": ["@microsoft/tsdoc@0.16.0", "", {}, "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA=="],
-
-    "@microsoft/tsdoc-config": ["@microsoft/tsdoc-config@0.18.1", "", { "dependencies": { "@microsoft/tsdoc": "0.16.0", "ajv": "~8.18.0", "jju": "~1.4.0", "resolve": "~1.22.2" } }, "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg=="],
-
-    "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+    "@mapleai/sdk": ["@mapleai/sdk@3.5.2", "", { "dependencies": { "@peculiar/x509": "1.14.3", "@stablelib/base64": "2.0.1", "@stablelib/chacha20poly1305": "2.0.1", "@stablelib/random": "2.0.1", "cbor2": "1.12.0", "openai": "5.23.2", "tweetnacl": "1.0.3", "zod": "3.25.76" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-AvFB1WAmbXwnmv2Vx7KblK3apbpyR+gqpya6Lpiz0xwSzkPX/y0cV1bjH1K3jz6Px1SqfK8LvqlK+0D8pSeetQ=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -360,8 +350,6 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
-    "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
-
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
 
     "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
@@ -411,16 +399,6 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
-
-    "@rushstack/node-core-library": ["@rushstack/node-core-library@5.23.3", "", { "dependencies": { "ajv": "~8.20.0", "ajv-draft-04": "~1.0.0", "ajv-formats": "~3.0.1", "fs-extra": "~11.3.0", "import-lazy": "~4.0.0", "jju": "~1.4.0", "resolve": "~1.22.1", "semver": "~7.7.4" }, "peerDependencies": { "@types/node": "*" }, "optionalPeers": ["@types/node"] }, "sha512-f6uuza7Um65bwsIJgf0MRs7IPA5IG+A+zs1AYGQvpZmLjtTGdfHowhQw4kwF0pPhJCrU4UHNhK8Qa6tLygYZCA=="],
-
-    "@rushstack/problem-matcher": ["@rushstack/problem-matcher@0.2.1", "", { "peerDependencies": { "@types/node": "*" }, "optionalPeers": ["@types/node"] }, "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog=="],
-
-    "@rushstack/rig-package": ["@rushstack/rig-package@0.7.3", "", { "dependencies": { "jju": "~1.4.0", "resolve": "~1.22.1" } }, "sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA=="],
-
-    "@rushstack/terminal": ["@rushstack/terminal@0.24.2", "", { "dependencies": { "@rushstack/node-core-library": "5.23.3", "@rushstack/problem-matcher": "0.2.1", "supports-color": "~8.1.1" }, "peerDependencies": { "@types/node": "*" }, "optionalPeers": ["@types/node"] }, "sha512-KB7PpvzDyKMw/RGU3TxOwxTs3OwZ4gq6+WHlTJN/JfQH4ezliNtWIqver78jTaAJyz/ZAAlJGH7a/M1WyFLFSw=="],
-
-    "@rushstack/ts-command-line": ["@rushstack/ts-command-line@5.3.12", "", { "dependencies": { "@rushstack/terminal": "0.24.2", "@types/argparse": "1.0.38", "argparse": "~1.0.9", "string-argv": "~0.3.1" } }, "sha512-Vg2n24arSf7JvUNga2DMHYTbxnVq9L5OtVCp4Gfr8YC/kmL/bmdR8FQhGcpMzMYNY9Vdw3+TaimG11Sf+z1Tpw=="],
 
     "@stablelib/aead": ["@stablelib/aead@2.0.0", "", {}, "sha512-U/RMANRxbT/ahIpYsPSiFwDFNjADHdnCFfmo09MO1ai2XmerPAOPtMl0qmX7XVvygnACC6ijKDyHBoT2rGyElg=="],
 
@@ -498,8 +476,6 @@
 
     "@tauri-apps/plugin-os": ["@tauri-apps/plugin-os@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A=="],
 
-    "@types/argparse": ["@types/argparse@1.0.38", "", {}, "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA=="],
-
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.6.8", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw=="],
@@ -540,8 +516,6 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
-    "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
-
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/type-utils": "8.59.0", "@typescript-eslint/utils": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg=="],
@@ -566,33 +540,11 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
-    "@volar/language-core": ["@volar/language-core@2.4.28", "", { "dependencies": { "@volar/source-map": "2.4.28" } }, "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ=="],
-
-    "@volar/source-map": ["@volar/source-map@2.4.28", "", {}, "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ=="],
-
-    "@volar/typescript": ["@volar/typescript@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "path-browserify": "^1.0.1", "vscode-uri": "^3.0.8" } }, "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw=="],
-
-    "@vue/compiler-core": ["@vue/compiler-core@3.5.41", "", { "dependencies": { "@babel/parser": "^7.29.8", "@vue/shared": "3.5.41", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg=="],
-
-    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.41", "", { "dependencies": { "@vue/compiler-core": "3.5.41", "@vue/shared": "3.5.41" } }, "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw=="],
-
-    "@vue/compiler-vue2": ["@vue/compiler-vue2@2.7.16", "", { "dependencies": { "de-indent": "^1.0.2", "he": "^1.2.0" } }, "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A=="],
-
-    "@vue/language-core": ["@vue/language-core@2.2.0", "", { "dependencies": { "@volar/language-core": "~2.4.11", "@vue/compiler-dom": "^3.5.0", "@vue/compiler-vue2": "^2.7.16", "@vue/shared": "^3.5.0", "alien-signals": "^0.4.9", "minimatch": "^9.0.3", "muggle-string": "^0.4.1", "path-browserify": "^1.0.1" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw=="],
-
-    "@vue/shared": ["@vue/shared@3.5.41", "", {}, "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA=="],
-
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
-
-    "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
-
-    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
-
-    "alien-signals": ["alien-signals@0.4.14", "", {}, "sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q=="],
 
     "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
@@ -666,10 +618,6 @@
 
     "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
-    "compare-versions": ["compare-versions@6.1.1", "", {}, "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="],
-
-    "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
-
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
@@ -679,8 +627,6 @@
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
-
-    "de-indent": ["de-indent@1.0.2", "", {}, "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg=="],
 
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
@@ -734,11 +680,7 @@
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
-
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
-
-    "exsolve": ["exsolve@1.1.1", "", {}, "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -749,8 +691,6 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
-
-    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fastq": ["fastq@1.19.0", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA=="],
 
@@ -770,8 +710,6 @@
 
     "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
 
-    "fs-extra": ["fs-extra@11.3.6", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA=="],
-
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
@@ -785,8 +723,6 @@
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
-
-    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -814,8 +750,6 @@
 
     "hastscript": ["hastscript@9.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^6.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-jzaLBGavEDKHrc5EfFImKN7nZKKBdSLIdGvCwDZ9TfzbF2ffXiov8CKE445L2Z1Ek2t/m4SKQ2j6Ipv7NyUolw=="],
 
-    "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
-
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
@@ -823,8 +757,6 @@
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
-
-    "import-lazy": ["import-lazy@4.0.0", "", {}, "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
@@ -860,8 +792,6 @@
 
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
-    "jju": ["jju@1.4.0", "", {}, "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="],
-
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.3.2", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA=="],
@@ -876,21 +806,15 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
-
     "katex": ["katex@0.16.45", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
-
-    "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
-
-    "local-pkg": ["local-pkg@1.2.1", "", { "dependencies": { "mlly": "^1.7.4", "pkg-types": "^2.3.0", "quansync": "^0.2.11" } }, "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
@@ -1010,11 +934,7 @@
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
-    "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
-
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
@@ -1046,8 +966,6 @@
 
     "parse5": ["parse5@7.2.1", "", { "dependencies": { "entities": "^4.5.0" } }, "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ=="],
 
-    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
-
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -1065,8 +983,6 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.6", "", {}, "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg=="],
-
-    "pkg-types": ["pkg-types@2.3.1", "", { "dependencies": { "confbox": "^0.2.4", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg=="],
 
     "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 
@@ -1093,8 +1009,6 @@
     "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
 
     "pvutils": ["pvutils@1.2.0", "", {}, "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg=="],
-
-    "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
@@ -1144,8 +1058,6 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
-    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
     "resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
@@ -1170,15 +1082,9 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
-
-    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
-    "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
     "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -1234,8 +1140,6 @@
 
     "typescript-eslint": ["typescript-eslint@8.59.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.0", "@typescript-eslint/parser": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/utils": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw=="],
 
-    "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
-
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
@@ -1253,8 +1157,6 @@
     "unist-util-visit": ["unist-util-visit@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg=="],
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw=="],
-
-    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "unplugin": ["unplugin@3.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.4", "webpack-virtual-modules": "^0.6.2" }, "peerDependencies": { "@farmfe/core": "*", "@rspack/core": "*", "bun-types-no-globals": "*", "esbuild": "*", "rolldown": "*", "rollup": "*", "unloader": "*", "vite": "*", "webpack": "*" }, "optionalPeers": ["@farmfe/core", "@rspack/core", "bun-types-no-globals", "esbuild", "rolldown", "rollup", "unloader", "vite", "webpack"] }, "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg=="],
 
@@ -1279,10 +1181,6 @@
     "vfile-message": ["vfile-message@4.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw=="],
 
     "vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
-
-    "vite-plugin-dts": ["vite-plugin-dts@4.5.4", "", { "dependencies": { "@microsoft/api-extractor": "^7.50.1", "@rollup/pluginutils": "^5.1.4", "@volar/typescript": "^2.4.11", "@vue/language-core": "2.2.0", "compare-versions": "^6.1.1", "debug": "^4.4.0", "kolorist": "^1.8.0", "local-pkg": "^1.0.0", "magic-string": "^0.30.17" }, "peerDependencies": { "typescript": "*", "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg=="],
-
-    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
@@ -1324,29 +1222,9 @@
 
     "@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
-    "@mapleai/sdk/@eslint/js": ["@eslint/js@9.39.5", "", {}, "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A=="],
-
-    "@mapleai/sdk/@types/bun": ["@types/bun@1.1.13", "", { "dependencies": { "bun-types": "1.1.34" } }, "sha512-KmQxSBgVWCl6RSuerlLGZlIWfdxkKqat0nxN61+qu4y1KDn0Ll3j7v1Pl8GnaL3a/U6GGWVTJh75ap62kR1E8Q=="],
-
-    "@mapleai/sdk/@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
-
-    "@mapleai/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "@mapleai/sdk/eslint": ["eslint@9.39.5", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.6", "@eslint/js": "9.39.5", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw=="],
-
     "@mapleai/sdk/openai": ["openai@5.23.2", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg=="],
 
-    "@mapleai/sdk/prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
-
-    "@mapleai/sdk/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
-
-    "@mapleai/sdk/typescript-eslint": ["typescript-eslint@8.66.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.66.0", "@typescript-eslint/parser": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/utils": "8.66.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw=="],
-
     "@mapleai/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@microsoft/api-extractor/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "@microsoft/tsdoc-config/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "@radix-ui/react-alert-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -1365,14 +1243,6 @@
     "@radix-ui/react-separator/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@rushstack/node-core-library/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "@rushstack/node-core-library/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "@rushstack/terminal/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
-
-    "@rushstack/ts-command-line/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "@tanstack/router-generator/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
@@ -1406,10 +1276,6 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
-    "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
-
-    "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
     "babel-dead-code-elimination/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
     "babel-dead-code-elimination/@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
@@ -1425,8 +1291,6 @@
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "micromark-extension-math/katex": ["katex@0.16.21", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A=="],
-
-    "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "openai/zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
@@ -1448,8 +1312,6 @@
 
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
-    "vite-plugin-dts/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -1459,30 +1321,6 @@
     "@babel/generator/@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
     "@jridgewell/remapping/@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
-
-    "@mapleai/sdk/@types/bun/bun-types": ["bun-types@1.1.34", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-br5QygTEL/TwB4uQOb96Ky22j4Gq2WxWH/8Oqv20fk5HagwKXo/akB+LiYgSfzexCt6kkcUaVm+bKiPl71xPvw=="],
-
-    "@mapleai/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@mapleai/sdk/eslint/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
-
-    "@mapleai/sdk/eslint/@eslint/eslintrc": ["@eslint/eslintrc@3.3.6", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.3.0", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA=="],
-
-    "@mapleai/sdk/eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
-
-    "@mapleai/sdk/eslint/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.66.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/type-utils": "8.66.0", "@typescript-eslint/utils": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.66.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/parser": ["@typescript-eslint/parser@8.66.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.66.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.66.0", "@typescript-eslint/tsconfig-utils": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/utils": ["@typescript-eslint/utils@8.66.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA=="],
-
-    "@microsoft/tsdoc-config/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@rushstack/node-core-library/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@types/babel__core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.25.9", "", {}, "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA=="],
 
@@ -1500,8 +1338,6 @@
 
     "@types/babel__traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.25.9", "", {}, "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="],
 
-    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
     "babel-dead-code-elimination/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "babel-dead-code-elimination/@babel/traverse/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
@@ -1514,8 +1350,6 @@
 
     "babel-dead-code-elimination/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
-
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -1526,68 +1360,10 @@
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "@mapleai/sdk/@types/bun/bun-types/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-scnD59RpYD91xngrQQLGkE+6UrHUPzeKZWhhjBSa3HSkwjbQc38+q3RoIVEwxQGRw3M+j5hpNAM+lgV3cVormg=="],
-
-    "@mapleai/sdk/eslint/@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/utils": "8.66.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/parser/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.66.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.66.0", "@typescript-eslint/types": "^8.66.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.66.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
-
     "babel-dead-code-elimination/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "babel-dead-code-elimination/@babel/traverse/@babel/generator/@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
-    "@mapleai/sdk/@types/bun/bun-types/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/parser/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
-
     "babel-dead-code-elimination/@babel/traverse/@babel/generator/@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
-
-    "@mapleai/sdk/typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
   }
 }

--- a/apps/maple-research/frontend/bunfig.toml
+++ b/apps/maple-research/frontend/bunfig.toml
@@ -4,6 +4,8 @@ frozenLockfile = true
 ignoreScripts = true
 auto = "disable"
 minimumReleaseAge = 604800
+# Our reviewed, protected SDK publisher supports immediate consumer upgrades.
+minimumReleaseAgeExcludes = ["@mapleai/sdk"]
 
 [test]
 preload = ["src/lib/test/preload.ts", "src/lib/test/der-loader.ts"]

--- a/apps/maple-research/frontend/package.json
+++ b/apps/maple-research/frontend/package.json
@@ -45,7 +45,7 @@
     "yaml": "^2.8.3"
   },
   "dependencies": {
-    "@mapleai/sdk": "file:../../../sdk",
+    "@mapleai/sdk": "3.5.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/maple-research/frontend/src-tauri/Cargo.lock
+++ b/apps/maple-research/frontend/src-tauri/Cargo.lock
@@ -4789,6 +4789,8 @@ dependencies = [
 [[package]]
 name = "maple-sdk"
 version = "3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9efa6ceaaddf0d1ff4d88448eacd48f3ebd6900a8c597d3b729b334750a5b4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/maple-research/frontend/src-tauri/Cargo.toml
+++ b/apps/maple-research/frontend/src-tauri/Cargo.toml
@@ -64,7 +64,7 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["std", "
 goose = { git = "https://github.com/aaif-goose/goose.git", rev = "f9c7aaccde4834810dfd13d5efa8f0d39ba28a20", package = "goose", default-features = false }
 goose-providers = { git = "https://github.com/aaif-goose/goose.git", rev = "f9c7aaccde4834810dfd13d5efa8f0d39ba28a20", package = "goose-providers", default-features = false }
 maple-proxy = { version = "0.3.3", path = "../../../../proxy" }
-maple-sdk = { version = "3.6.2", path = "../../../../sdk/rust" }
+maple-sdk = "=3.6.2"
 axum = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }
 rand = "0.8.6"

--- a/docs/sdk-publishing.md
+++ b/docs/sdk-publishing.md
@@ -16,7 +16,80 @@ GitHub Releases and Maple app updates.
 The initial workflow supports stable `X.Y.Z` versions only. It publishes the
 version already committed on protected `master`; it does not bump versions,
 commit files, or release the Maple application. Prepare subsequent SDK version
-changes in a normal PR, including the relevant lockfiles and consumer updates.
+changes in a normal PR, including the SDK's lockfile. Consumer upgrades are
+separate choices; publishing does not update application dependencies.
+
+## Consumer version policy
+
+Prefer published SDK versions for client applications, with each consumer
+choosing when to upgrade. Pin application manifests exactly and commit their
+lockfiles. The Research frontend starts at `@mapleai/sdk` `3.5.2`; Research
+desktop and Maple Agent independently start at `maple-sdk` `=3.6.2`. The reusable
+proxy library uses a compatible SDK requirement (`3.6.2`), so its embedding
+application can choose the version. The standalone proxy has its own lockfile.
+An SDK publication should not automatically upgrade every consumer, and an
+older published pin is not a reason to block an unrelated client release.
+
+Local SDK dependencies are supported during active development, including on
+`master`. Edit the existing manifest and regenerate its lockfile with the
+owning component's pinned tools; no special development mode is required:
+
+- TypeScript can use `file:../../../sdk` from the Research frontend and return
+  to an exact registry version when ready. A local package version does not
+  freeze its source; frontend preparation builds the selected local SDK.
+- Rust can use a Cargo `path` dependency or a root `[patch.crates-io]` override
+  for `maple-sdk`. Keep the host app and embedded proxy on the same SDK source
+  and version because they exchange SDK types. A patch belongs in the
+  consuming Cargo workspace root, not only the SDK or proxy manifest. Update
+  the selected dependency requirements and affected lockfiles together; a
+  `version` alongside `path` checks compatibility, but still builds local
+  source. Remove local overrides when returning to a published pin.
+
+Research's `bunfig.toml` defaults to `install.frozenLockfile = true`. To switch
+its SDK dependency, temporarily set only that setting to `false`, enter the
+root's pinned Nix shell, and run **one** command from
+`apps/maple-research/frontend/`:
+
+```sh
+# Published version:
+bun --no-env-file add --exact @mapleai/sdk@3.5.2 --ignore-scripts
+# Or local source:
+bun --no-env-file add --exact @mapleai/sdk@file:../../../sdk --ignore-scripts
+```
+
+Restore `frozenLockfile = true` immediately, including if the command fails;
+leave dependency-age and script-execution protections unchanged. Review the
+manifest/lockfile delta, then run `just install` from the monorepo root to
+validate the selected dependency through the normal frozen install path.
+
+Before releasing a client, proxy, or CLI, inspect what that consumer will
+actually ship. For Research's frontend, check the `@mapleai/sdk` entry in both
+`apps/maple-research/frontend/package.json` and its adjacent `bun.lock`. For a Rust consumer,
+run this in its pinned environment, substituting its manifest path:
+
+```sh
+cargo metadata --locked --format-version 1 --manifest-path PATH/TO/Cargo.toml \
+  | jq '.packages[] | select(.name == "maple-sdk") | {version, source, manifest_path}'
+```
+
+A registry source and locked version identify the published crate; a null
+source and the in-repository manifest identify local source. Inspect overrides
+as well as direct dependencies. A local SDK can have unpublished changes even
+when its version matches the registry. Compare the relevant published source
+commit/provenance or package contents when deciding whether SDK runtime changes
+will ship.
+
+If a release includes unpublished SDK changes, recommend publishing that SDK
+and pinning the affected consumer before releasing the client. This is a
+release-preparation preference, not a mandatory gate or a new approval step.
+An intentional release with local SDK source is allowed; record that source
+and the exact monorepo commit in the release handoff. Registry publishing keeps
+its existing protected workflow and authorization requirements below. Ordinary
+client work does not authorize an SDK publication.
+
+Validate the selected dependency mode and lockfile. SDK source and backend
+integration checks continue to exercise the in-tree SDK; passing a client build
+that consumes a registry version does not validate unpublished SDK source.
 
 ## Run a release
 

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1469,6 +1469,8 @@ dependencies = [
 [[package]]
 name = "maple-sdk"
 version = "3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9efa6ceaaddf0d1ff4d88448eacd48f3ebd6900a8c597d3b729b334750a5b4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -28,8 +28,8 @@ name = "maple-proxy"
 path = "src/main.rs"
 
 [dependencies]
-# OpenSecret SDK
-maple-sdk = { version = "3.6.2", path = "../sdk/rust" }
+# Let embedded consumers select a compatible SDK; Cargo.lock pins standalone builds.
+maple-sdk = "3.6.2"
 
 # Web server
 axum = { version = "0.8.4", features = ["http2", "macros"] }

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -54,10 +54,12 @@ maple-proxy = "0.3.2"
 Crates.io publishing remains separate from Maple application releases; the
 example above uses the latest published crate version.
 
-The current source consumes the in-tree `maple-sdk` crate through a versioned
-path dependency. That SDK's registry ownership and first publication are
-pending. Publish the SDK before packaging or publishing a proxy crate that
-depends on its new registry name; local path builds work before publication.
+The source uses a compatible `maple-sdk` registry requirement, starting at
+`3.6.2`. The standalone binary's lockfile selects its SDK version; an embedding
+application selects its own. Keep the host and proxy on one SDK source/version
+because their public APIs exchange SDK types. Local SDK links are supported
+for active development. See the [SDK consumer version policy](../docs/sdk-publishing.md#consumer-version-policy).
+A proxy crate publication still requires its SDK dependency to be published.
 
 ## ⚙️ Configuration
 
@@ -445,7 +447,8 @@ verification; local recipes intentionally cannot publish to it.
 
 `proxy/Cargo.lock`, `sdk/rust/Cargo.lock`, and
 `apps/maple-research/frontend/src-tauri/Cargo.lock` remain separate lockfiles. Runtime dependency
-changes must keep the path graph and all affected locks coherent. Docker builds
+changes must keep the selected SDK sources and affected locks coherent; one
+consumer's SDK upgrade does not require upgrading the others. Docker builds
 must use the Maple repository root as context so both `proxy/` and `sdk/rust/`
 are available. GitHub Release archives, crates.io, and GHCR are three separate
 publication paths; completing one does not update the others.

--- a/scripts/ci/proxy_runtime_diff.py
+++ b/scripts/ci/proxy_runtime_diff.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Compare proxy container inputs; exit like git diff --quiet (0/1/2).
+
+The committed standalone lockfile selects the SDK actually compiled by Docker.
+Include in-tree SDK source when either revision uses it, including a Cargo patch.
+"""
+
+import subprocess
+import sys
+import tomllib
+
+
+PROXY_INPUTS = [
+    "proxy/Dockerfile",
+    "proxy/Cargo.toml",
+    "proxy/Cargo.lock",
+    "proxy/src",
+]
+SDK_INPUTS = ["sdk/rust/Cargo.toml", "sdk/rust/src", "sdk/rust/assets"]
+
+
+def git_output(*args):
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def uses_local_sdk(sha):
+    lock = tomllib.loads(git_output("show", f"{sha}:proxy/Cargo.lock"))
+    sdk_packages = [
+        package
+        for package in lock.get("package", [])
+        if package.get("name") in ("maple-sdk", "opensecret")
+    ]
+    if len(sdk_packages) != 1:
+        raise ValueError("proxy lockfile must identify exactly one Maple SDK")
+    return "source" not in sdk_packages[0]
+
+
+def runtime_diff(from_ref, to_ref):
+    revisions = [
+        git_output("rev-parse", "--verify", "--end-of-options", f"{ref}^{{commit}}").strip()
+        for ref in (from_ref, to_ref)
+    ]
+    # Inspect both revisions before comparing, including local/registry transitions.
+    local_sdk = [uses_local_sdk(sha) for sha in revisions]
+    paths = PROXY_INPUTS + (SDK_INPUTS if any(local_sdk) else [])
+    result = subprocess.run(["git", "diff", "--quiet", *revisions, "--", *paths])
+    return result.returncode if result.returncode in (0, 1) else 2
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: proxy_runtime_diff.py FROM_REF TO_REF", file=sys.stderr)
+        return 2
+    try:
+        return runtime_diff(*sys.argv[1:])
+    except (OSError, subprocess.CalledProcessError, ValueError, TypeError, AttributeError) as exc:
+        print(f"Could not compare proxy container runtime inputs: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test-release-gates.sh
+++ b/scripts/ci/test-release-gates.sh
@@ -528,6 +528,7 @@ for required_control in (
     "proxy container runtime inputs changed without a proxy version bump",
     '"${UNBACKFILLED_PROXY_BASELINE}"',
     "plan-proxy-container-publish.sh",
+    "python3 -I scripts/ci/proxy_runtime_diff.py",
     "python3 -I scripts/ci/proxy_registry_inventory.py",
 ):
     check(required_control in prepare_runs, f"Proxy publication plan is missing control: {required_control}")
@@ -626,6 +627,7 @@ for required_control in (
     "inspect-proxy-container-manifest.sh",
     "python3 -I scripts/ci/proxy_registry_inventory.py --require-public",
     "published exact tag does not match the current proxy runtime inputs",
+    "python3 -I scripts/ci/proxy_runtime_diff.py",
     'for tag in "${PROXY_MINOR}" "${PROXY_MAJOR}" latest',
     "docker buildx imagetools create",
     "per-platform SLSA provenance",
@@ -654,5 +656,8 @@ pass "proxy container publish planner preserves immutable versions and recovery"
 
 python3 "${script_dir}/test_proxy_registry_inventory.py" >/dev/null
 pass "proxy registry inventory distinguishes initial creation from failed access"
+
+python3 "${script_dir}/test_proxy_runtime_diff.py" >/dev/null
+pass "proxy runtime comparisons follow the SDK selected at both revisions"
 
 printf '1..%d\n' "${passed}"

--- a/scripts/ci/test_agent_rust_deps.py
+++ b/scripts/ci/test_agent_rust_deps.py
@@ -1,4 +1,4 @@
-"""The Agent import must not reintroduce a second SDK or a registry proxy."""
+"""Both SDK modes must preserve one SDK identity and the local embedded proxy."""
 
 import copy
 import importlib.util
@@ -15,39 +15,82 @@ spec.loader.exec_module(verifier)
 
 
 class AgentRustDependencyTests(unittest.TestCase):
-    def test_local_graph_passes_and_misdirected_or_duplicate_crates_fail(self):
+    def graph(self, root, registry=False):
+        graph = {"packages": [
+            {"name": name, "version": "3.6.2" if name == "maple-sdk" else "0.3.4",
+             "source": None, "manifest_path": str(root / manifest)}
+            for name, manifest in verifier.DEPENDENCIES.items()
+        ]}
+        if registry:
+            graph["packages"][0].update(
+                source=verifier.CRATES_IO,
+                manifest_path=str(root / "registry" / "maple-sdk-3.6.2" / "Cargo.toml"),
+            )
+        return graph
+
+    def test_local_and_published_graphs_pass(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            graph = {"packages": [
-                {"name": name, "source": None, "manifest_path": str(root / manifest)}
-                for name, manifest in verifier.DEPENDENCIES.items()
-            ]}
-            verifier.verify(graph, root)
-            legacy = copy.deepcopy(graph)
+            for registry in (False, True):
+                with self.subTest(registry=registry):
+                    verifier.verify(self.graph(root, registry), root)
+
+    def test_consumer_version_need_not_equal_current_sdk_source(self):
+        root = Path("/maple")
+        graph = self.graph(root, registry=True)
+        # Cargo --locked validates the consumer's requirement. This guard must
+        # not require consumers to upgrade when monorepo SDK development moves.
+        graph["packages"][0]["version"] = "3.6.1"
+        verifier.verify(graph, root)
+
+    def test_legacy_sdk_fails(self):
+        root = Path("/maple")
+        for registry in (False, True):
+            legacy = self.graph(root, registry)
             legacy["packages"].append({
                 "name": "opensecret",
-                "source": "registry+https://github.com/rust-lang/crates.io-index",
+                "source": verifier.CRATES_IO,
                 "manifest_path": str(root / "registry" / "opensecret" / "Cargo.toml"),
             })
             with self.assertRaisesRegex(ValueError, "legacy opensecret SDK"):
                 verifier.verify(legacy, root)
+
+    def test_misdirected_missing_or_duplicate_crates_fail(self):
+        root = Path("/maple")
+        for registry in (False, True):
+            graph = self.graph(root, registry)
             for name in verifier.DEPENDENCIES:
-                for alteration in ("duplicate", "missing", "registry", "fork", "other_checkout"):
-                    with self.subTest(name=name, alteration=alteration):
+                for alteration in ("duplicate", "missing", "other_registry", "fork", "other_checkout"):
+                    with self.subTest(registry=registry, name=name, alteration=alteration):
                         changed = copy.deepcopy(graph)
                         package = next(p for p in changed["packages"] if p["name"] == name)
                         if alteration == "duplicate":
                             changed["packages"].append(copy.deepcopy(package))
                         elif alteration == "missing":
                             changed["packages"].remove(package)
-                        elif alteration == "registry":
-                            package["source"] = "registry+https://github.com/rust-lang/crates.io-index"
+                        elif alteration == "other_registry":
+                            package["source"] = "registry+https://example.com/crates.io-index"
                         elif alteration == "fork":
                             package["source"] = "git+https://github.com/example/fork"
                         else:
+                            package["source"] = None
                             package["manifest_path"] = str(root / "other" / "Cargo.toml")
                         with self.assertRaises(ValueError):
                             verifier.verify(changed, root)
+
+    def test_registry_proxy_fails(self):
+        root = Path("/maple")
+        graph = self.graph(root, registry=True)
+        graph["packages"][1]["source"] = verifier.CRATES_IO
+        with self.assertRaisesRegex(ValueError, "monorepo's proxy/Cargo.toml"):
+            verifier.verify(graph, root)
+
+    def test_mixed_local_and_registry_sdk_identities_fail(self):
+        root = Path("/maple")
+        graph = self.graph(root)
+        graph["packages"].append(self.graph(root, registry=True)["packages"][0])
+        with self.assertRaisesRegex(ValueError, "exactly one maple-sdk"):
+            verifier.verify(graph, root)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_proxy_runtime_diff.py
+++ b/scripts/ci/test_proxy_runtime_diff.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Release comparisons follow the SDK selected by each standalone proxy lockfile."""
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+HELPER = Path(__file__).with_name("proxy_runtime_diff.py").resolve()
+
+
+class ProxyRuntimeDiffTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.git("init", "-q")
+        self.git("config", "user.name", "Proxy release tests")
+        self.git("config", "user.email", "proxy-tests@example.invalid")
+        self.write("proxy/Cargo.toml", '[package]\nname = "maple-proxy"\nversion = "0.3.4"\n')
+        self.write("proxy/src/main.rs", "fn main() {}\n")
+        self.write("proxy/Dockerfile", "FROM fixture\n")
+        self.write("sdk/rust/src/lib.rs", "// SDK source\n")
+
+    def git(self, *args):
+        return subprocess.run(
+            ["git", *args], cwd=self.root, check=True, capture_output=True, text=True
+        ).stdout.strip()
+
+    def write(self, name, content):
+        path = self.root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def sdk_lock(self, local, name="maple-sdk"):
+        source = "" if local else 'source = "registry+https://github.com/rust-lang/crates.io-index"\n'
+        self.write(
+            "proxy/Cargo.lock",
+            f'version = 4\n[[package]]\nname = "{name}"\nversion = "3.6.2"\n{source}',
+        )
+
+    def commit(self):
+        self.git("add", ".")
+        self.git("commit", "-qm", "fixture")
+        return self.git("rev-parse", "HEAD")
+
+    def compare(self, before, after):
+        return subprocess.run(
+            [sys.executable, "-I", str(HELPER), before, after],
+            cwd=self.root, capture_output=True, text=True,
+        ).returncode
+
+    def test_pinned_proxy_ignores_unconsumed_sdk_source(self):
+        self.sdk_lock(local=False)
+        before = self.commit()
+        self.write("sdk/rust/src/lib.rs", "// Unreleased SDK change\n")
+        after = self.commit()
+        self.assertEqual(self.compare(before, after), 0)
+
+    def test_local_sdk_changes_count_for_old_and_new_package_names(self):
+        for name in ("opensecret", "maple-sdk"):
+            with self.subTest(name=name):
+                self.sdk_lock(local=True, name=name)
+                before = self.commit()
+                self.write("sdk/rust/src/lib.rs", f"// {name} change\n")
+                after = self.commit()
+                self.assertEqual(self.compare(before, after), 1)
+
+    def test_source_mode_transitions_count_in_both_directions(self):
+        self.sdk_lock(local=True)
+        local = self.commit()
+        self.sdk_lock(local=False)
+        pinned = self.commit()
+        self.assertEqual(self.compare(local, pinned), 1)
+        self.assertEqual(self.compare(pinned, local), 1)
+
+    def test_pinned_proxy_still_tracks_its_own_build_inputs(self):
+        self.sdk_lock(local=False)
+        before = self.commit()
+        for path in ("proxy/Cargo.toml", "proxy/Cargo.lock", "proxy/Dockerfile", "proxy/src/main.rs"):
+            with self.subTest(path=path):
+                original = (self.root / path).read_text(encoding="utf-8")
+                self.write(path, original + "\n# changed\n")
+                after = self.commit()
+                self.assertEqual(self.compare(before, after), 1)
+                self.write(path, original)
+                before = self.commit()
+
+    def test_missing_or_ambiguous_sdk_and_invalid_refs_fail_as_errors(self):
+        self.sdk_lock(local=False)
+        before = self.commit()
+        self.assertEqual(self.compare(before, "missing-revision"), 2)
+        for content in (
+            "version = 4\n",
+            "invalid toml",
+            '[[package]]\nname = "maple-sdk"\n[[package]]\nname = "opensecret"\n',
+        ):
+            with self.subTest(content=content):
+                self.write("proxy/Cargo.lock", content)
+                after = self.commit()
+                self.assertEqual(self.compare(before, after), 2)
+                self.assertEqual(self.compare(after, before), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/verify-agent-rust-deps.py
+++ b/scripts/ci/verify-agent-rust-deps.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Reject registry/fork duplicates of the SDK and proxy in Agent's Cargo graph."""
+"""Check the SDK and embedded proxy identities in Research and Agent graphs."""
 
 import json
 from pathlib import Path
@@ -8,18 +8,24 @@ import sys
 
 ROOT = Path(__file__).resolve().parents[2]
 DEPENDENCIES = {"maple-sdk": "sdk/rust/Cargo.toml", "maple-proxy": "proxy/Cargo.toml"}
+CRATES_IO = "registry+https://github.com/rust-lang/crates.io-index"
 
 
 def verify(metadata: dict, root: Path = ROOT) -> None:
     if any(package["name"] == "opensecret" for package in metadata["packages"]):
-        raise ValueError("Agent must not resolve the legacy opensecret SDK alongside maple-sdk")
+        raise ValueError("Maple must not resolve the legacy opensecret SDK alongside maple-sdk")
     for name, relative in DEPENDENCIES.items():
         packages = [package for package in metadata["packages"] if package["name"] == name]
         if len(packages) != 1:
-            raise ValueError(f"Agent must resolve exactly one {name} crate")
+            raise ValueError(f"Maple must resolve exactly one {name} crate")
         package = packages[0]
+        if name == "maple-sdk" and package.get("source") == CRATES_IO:
+            continue
         if package.get("source") is not None or Path(package["manifest_path"]).resolve() != (root / relative).resolve():
-            raise ValueError(f"Agent must resolve {name} from the monorepo's {relative}")
+            allowed = f"the monorepo's {relative}"
+            if name == "maple-sdk":
+                allowed += " or crates.io"
+            raise ValueError(f"Maple must resolve {name} from {allowed}")
 
 
 def main() -> int:
@@ -31,7 +37,9 @@ def main() -> int:
         verify(metadata)
     except (KeyError, ValueError) as error:
         raise SystemExit(str(error)) from None
-    print("Maple Agent resolves exactly one in-tree Maple SDK and proxy crate, with no legacy SDK.")
+    sdk = next(package for package in metadata["packages"] if package["name"] == "maple-sdk")
+    source = "crates.io" if sdk.get("source") == CRATES_IO else "local sdk/rust"
+    print(f"Maple resolves maple-sdk {sdk['version']} from {source}, with one local proxy and no legacy SDK.")
     return 0
 
 

--- a/scripts/ci/verify-local-rust-deps.sh
+++ b/scripts/ci/verify-local-rust-deps.sh
@@ -11,14 +11,6 @@ cargo metadata \
   --manifest-path apps/maple-research/frontend/src-tauri/Cargo.toml \
   --format-version 1 > "${metadata_file}"
 
-jq -e --arg root "${repo_root}" '
-  ([.packages[] | select(.name == "opensecret")] | length) == 0 and
-  ([.packages[] | select(.name == "maple-sdk")] | length) == 1 and
-  ([.packages[] | select(.name == "maple-proxy")] | length) == 1 and
-  ([.packages[] | select(.name == "maple-sdk")][0].source == null) and
-  ([.packages[] | select(.name == "maple-sdk")][0].manifest_path == ($root + "/sdk/rust/Cargo.toml")) and
-  ([.packages[] | select(.name == "maple-proxy")][0].source == null) and
-  ([.packages[] | select(.name == "maple-proxy")][0].manifest_path == ($root + "/proxy/Cargo.toml"))
-' "${metadata_file}" > /dev/null
-
-echo "Maple resolves exactly one in-tree Maple SDK and proxy crate, with no legacy SDK."
+# Research and Agent share the same SDK/proxy identity constraints. Cargo's
+# --locked resolution above checks that declarations and the lockfile agree.
+python3 scripts/ci/verify-agent-rust-deps.py "${metadata_file}"

--- a/scripts/prepare-frontend-deps.sh
+++ b/scripts/prepare-frontend-deps.sh
@@ -6,8 +6,12 @@ if [ "${MAPLE_FRONTEND_DEPS_PREPARED:-0}" = "1" ]; then
 fi
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+frontend_dir="${repo_root}/apps/maple-research/frontend"
 
-"${repo_root}/scripts/prepare-typescript-sdk.sh"
+sdk_dependency="$(bun --no-env-file -p 'require(process.argv[1]).dependencies["@mapleai/sdk"]' "${frontend_dir}/package.json")"
+if [ "${sdk_dependency}" = "file:../../../sdk" ]; then
+  "${repo_root}/scripts/prepare-typescript-sdk.sh"
+fi
 
-cd "${repo_root}/apps/maple-research/frontend"
+cd "${frontend_dir}"
 bun --no-env-file install --frozen-lockfile --ignore-scripts

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -20,18 +20,18 @@ and tests.
 - repository-root `.github/workflows/sdk-*.yml` — path-scoped TypeScript, Rust,
   and supply-chain validation for this directory.
 
-Maple's frontend consumes this TypeScript package through `file:../../../sdk`.
-Desktop Maple and `proxy/` consume `sdk/rust` through versioned path
-dependencies; iOS and Android exclude those desktop-only Rust consumers.
-Published npm and crates.io packages remain independently versioned.
+Maple consumers prefer independently selected published SDK versions; local
+TypeScript `file:` and Rust `path` dependencies remain available for active
+development. The consumer's manifest and lockfile determine what it builds.
+iOS and Android exclude the desktop-only Rust SDK/proxy consumers. See the
+[consumer version policy](../docs/sdk-publishing.md#consumer-version-policy)
+for switching sources and preparing client releases.
 
 ## Package identity migration
 
-The new package names are `@mapleai/sdk` and `maple-sdk`. This source change
-retains TypeScript version 3.5.2 and Rust version 3.6.2; first publication and
-registry ownership are separate steps. Until those packages are published,
-develop against the in-tree dependencies above. The registry installation
-examples below describe the new package identities after publication.
+The package names are `@mapleai/sdk` and `maple-sdk`, first published at
+TypeScript version 3.5.2 and Rust version 3.6.2. Their versions and publication
+remain independent of Maple application releases.
 
 The rename preserves the exported API, including `OpenSecretProvider`,
 `useOpenSecret`, `OpenSecretDeveloper` and `OpenSecretClient`. OpenSecret remains
@@ -59,7 +59,7 @@ production paths.
 Install the package:
 
 ```sh
-bun add @mapleai/sdk
+bun add --exact @mapleai/sdk@3.5.2
 ```
 
 Wrap the application with `OpenSecretProvider` and supply the backend URL and
@@ -144,7 +144,7 @@ Add the crate to a Rust application:
 
 ```toml
 [dependencies]
-maple-sdk = "3.6.2"
+maple-sdk = "=3.6.2"
 ```
 
 Import the primary entry point with `use maple_sdk::OpenSecretClient`.


### PR DESCRIPTION
Consumers previously always built the SDK source in the monorepo, coupling SDK development to every app and proxy release. This change defaults Research's frontend to `@mapleai/sdk` 3.5.2 and independently pins Research and Agent to `maple-sdk` 3.6.2. The reusable proxy accepts a compatible SDK version while its standalone lockfile fixes the deployed version.

Local `file:` and Cargo path/patch dependencies remain supported, including on `master`. The existing developer and release guidance recommends publishing and pinning an SDK before a client ships its unpublished changes, while allowing an intentional local-source release. There is no new policy gate or approval mechanism.

- Frontend preparation builds SDK source only when the consumer selects the local package. Its lockfile drops unused SDK development dependencies without changing retained third-party versions. Only `@mapleai/sdk` is exempted from the seven-day package-age delay so reviewed first-party SDK releases can be adopted immediately.
- Existing Rust graph checks accept canonical local source or crates.io and retain the single-SDK/local-proxy identity checks. All three Rust lockfiles change only the SDK registry source and checksum.
- Existing proxy version and immutable-image checks compare SDK source only when either revision's proxy lockfile consumes it locally. Publishing security and release authorization remain unchanged.

Validation passed:

- Host Nix flake checks, including workflow and publishing-boundary checks.
- Published and local npm preparation/runtime fixtures; frontend lint/typecheck.
- Normal commit hook: frontend formatting/build and 818 tests; Research native all-target tests, 415 passed and two existing ignores. The fresh workspace first needed the existing checksum-verified ONNX Runtime setup.
- Three locked Rust metadata graphs; six Rust graph tests; five proxy comparison tests and the release-gate suite. Registry Rust SDK source/assets match current monorepo bytes.
- Validation of all nine modified Skills; independent code/security and guidance reviews.

Cross-platform CI and deployed behavior remain separate checks. This PR does not publish an SDK or application release.
