### PR TITLE
Refresh current monorepo setup and component documentation

### DIFF
--- a/.agents/skills/change-maple-agent-mode/SKILL.md
+++ b/.agents/skills/change-maple-agent-mode/SKILL.md
@@ -39,10 +39,11 @@ Use these seams:
 - `apps/maple-research/frontend/src-tauri/src/agent.rs`: transport-neutral Agent domain state, account handles, Goose/session orchestration, persistence, run ownership, timelines, MCP and skills attachment, and permission routing. Do not import Tauri or ACP protocol types into this core.
 - `apps/maple-research/frontend/src-tauri/src/agent/provider.rs`: Goose-provider request construction, encrypted inference transport, streaming, bounded error handling, retry policy, and cancellation.
 - `apps/maple-research/frontend/src-tauri/src/maple_api.rs`: account-scoped native OpenSecret SDK sessions, backend identity validation, atomic credential replacement, and refresh reconciliation.
-- `sdk/rust/`: source for the OpenSecret Rust SDK consumed by Maple's desktop
-  application through the path dependency in `apps/maple-research/frontend/src-tauri/Cargo.toml`.
-  Rust SDK runtime changes therefore reach Agent Mode desktop builds; verify
-  the local dependency graph rather than treating the in-tree source as inert.
+- `sdk/rust/`: source for the Maple Rust SDK. Research selects a published
+  version or local source through `apps/maple-research/frontend/src-tauri/Cargo.toml`
+  and its lockfile. Follow the [consumer version policy](../../../docs/sdk-publishing.md#consumer-version-policy)
+  and verify the resolved graph before claiming an SDK source edit reaches
+  Agent Mode; a registry-pinned build does not exercise that edit.
 - `apps/maple-research/frontend/src-tauri/src/agent/developer_tools.rs`: Maple's privileged read, write, edit, image, shell, and backend web-tool implementations. Add privileged tools here rather than exposing an unmediated Goose tool path.
 - `apps/maple-research/frontend/src-tauri/src/agent/{shell_permission,web_permission,tool_context,web_tools}.rs`: automatic policy, secret-bearing execution context, public-URL admission, provenance, and output bounds.
 - `apps/maple-research/frontend/src-tauri/src/agent/system_prompt.rs`: the narrowly rebranded copy of the pinned Goose system prompt.

--- a/.agents/skills/develop-opensecret-sdk/SKILL.md
+++ b/.agents/skills/develop-opensecret-sdk/SKILL.md
@@ -64,7 +64,7 @@ nix develop --no-update-lock-file -c bash -lc '
   cd rust
   cargo fmt --all -- --check
   cargo clippy --locked --all-targets --all-features -- -D warnings
-  cargo test --locked --all-features
+  cargo test --locked --all-features --lib
   cargo doc --locked --no-deps --all-features
 '
 ```

--- a/.agents/skills/validate-opensecret/SKILL.md
+++ b/.agents/skills/validate-opensecret/SKILL.md
@@ -145,11 +145,12 @@ the corresponding Maple application client:
    usage when promised, and one terminal condition.
 5. Inspect bounded logs for accidental sensitive content.
 
-Follow the matching SDK and application validation skills. The monorepo-root
-`apps/maple-research/frontend/package.json` resolves the browser's in-tree
-`file:../../../sdk` dependency. Research desktop, the proxy, and the GPUI
-prototype consume `sdk/rust` through versioned path dependencies in their
-component `Cargo.toml` files. Root `sdk-integration.yml` runs both SDKs against
+Follow the matching SDK and application validation skills. Each consumer's
+manifest and lockfile select its SDK version and source; published pins are
+the default, with local links supported under the
+[consumer version policy](../../../docs/sdk-publishing.md#consumer-version-policy).
+Verify that selection before using an application build as evidence for an SDK
+source edit. Root `sdk-integration.yml` runs both in-tree SDKs against
 the backend in the same checkout with disposable PostgreSQL and loopback
 configuration. That deterministic gate does not prove an application or live
 provider flow. Test browser Research and affected native paths independently;

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ application identity.
 | --- | --- |
 | [`apps/maple-research/`](apps/maple-research/README.md) | React/Vite frontend and Tauri desktop/mobile application, app documentation, and distribution configuration |
 | [`apps/maple-agent/`](apps/maple-agent/README.md) | GPUI desktop-v2 prototype, ACP agent, and CLI proxy; independent from the shipped Research app |
-| [`sdk/`](sdk/README.md) | Maple TypeScript/React and Rust SDKs, consumed in tree by Maple |
+| [`sdk/`](sdk/README.md) | Independently published Maple TypeScript/React and Rust SDKs |
 | [`proxy/`](proxy/README.md) | Standalone OpenAI-compatible proxy, also consumed by desktop Maple |
 | [`services/updates/`](services/updates/README.md) | Desktop updater Worker and verified release-metadata publishing |
 | [`services/opensecret/`](services/opensecret/README.md) | Confidential authentication, inference, conversations, and related backend APIs; local Nitro tooling and signed PCR files |
@@ -46,6 +46,9 @@ Preserve existing configuration and externally managed workspace resources.
 All `VITE_*` values are public client configuration and must never contain secrets.
 Root `justfile`, `flake.nix`, `.agents/`, and CI scripts remain shared entry points;
 use each component's guide for its direct Bun or Cargo commands.
+Consumers select their SDK versions independently. Published pins are the
+default, with local links available for development; follow the
+[SDK consumer version policy](docs/sdk-publishing.md#consumer-version-policy).
 OpenSecret retains its own pinned Nix shell and Rust package: enter
 `services/opensecret/` before running its commands, and follow its
 [setup guide](services/opensecret/README.md#local-quick-start) for stateful
@@ -64,6 +67,8 @@ GitHub Release starts cross-platform packaging and downstream publication. Use
 [the release procedure](.agents/skills/release-maple/SKILL.md) only for authorized
 release work. The [Pages guide](docs/pages-deployments.md) documents preview and
 production deployment profiles and controls.
+SDK publication uses separate protected manual workflows and does not create
+a Maple application release; see the [SDK publishing guide](docs/sdk-publishing.md).
 OpenSecret's root CI workflows validate code and in-tree SDK compatibility;
 they do not publish EIFs or deploy the TEE service. Backend deployment and
 [manual signed-PCR publication](services/opensecret/docs/pcr-compatibility.md)

--- a/apps/maple-agent/README.md
+++ b/apps/maple-agent/README.md
@@ -450,12 +450,14 @@ the namespace. Local `just release` and `just dist` only build local files.
 
 ## Shared dependencies and provenance
 
-The component consumes the in-tree `maple-sdk` crate at `../../sdk/rust`
-and `maple-proxy` at `../../proxy` through workspace dependencies. The SDK fork
-patch is removed; registry publication is not needed for local
-builds. Keep the component lockfile and Nix source fileset aligned with these
-path dependencies. The pure package includes the required SDK attestation
-assets as well as Rust source.
+The workspace manifest and lockfile independently select a published
+`maple-sdk` version; the former SDK fork patch is removed. The component still
+consumes `maple-proxy` at `../../proxy`. Local SDK links to `../../sdk/rust`
+remain supported for development under the
+[SDK consumer version policy](../../docs/sdk-publishing.md#consumer-version-policy).
+Keep Agent and its embedded proxy on one resolved SDK source/version. The Nix
+source fileset includes the local SDK source and attestation assets so local
+links work too; a registry-pinned build uses its locked registry package.
 
 See [import provenance and follow-up work](../../docs/maple-agent-import.md).
 This component preserves the original GPUI history; its old nested workflows

--- a/apps/maple-research/AGENTS.md
+++ b/apps/maple-research/AGENTS.md
@@ -220,9 +220,9 @@ dependency.
 
 For Pages publishing, read [the deployment guide](../../docs/pages-deployments.md).
 Keep preview builds unprivileged, preserve development/production build profiles,
-and run credential-bearing publication only from trusted master. The new Pages
-publisher is opt-in; deployment flags, protected environments, and native CF
-build controls are separate operator prerequisites, not consequences of merging.
+and run credential-bearing publication only from trusted master. Repository
+variables control Pages publication; protected environments and native CF build
+controls are separate operator settings, not consequences of merging.
 
 PR artifact scripts deliberately ignore local `.env*` files and compile fixed
 PR endpoints. They prove PR packaging, not a configured local-backend runtime.
@@ -239,7 +239,7 @@ change-to-evidence matrix and full-stack smoke procedure.
 
 ## External services and full-stack work
 
-- Run OpenSecret using that repository's own instructions and migrations, then
+- Run OpenSecret from `services/opensecret/` using its component guide and migrations, then
   point `VITE_OPEN_SECRET_API_URL` to it. Do not copy backend secrets into
   Maple.
 - Feature flags and billing are independent API clients. Configure their dev

--- a/apps/maple-research/README.md
+++ b/apps/maple-research/README.md
@@ -2,17 +2,20 @@
 
 Maple Research is the existing Maple client, built with React, Vite, and Tauri.
 It runs as a web application and as native desktop/mobile applications, and uses
-[OpenSecret](https://github.com/OpenSecretCloud/opensecret) for confidential
+[OpenSecret](../../services/opensecret/README.md) for confidential
 authentication, inference, conversations, and related APIs.
 
 Research chat and desktop Agent Mode are different client paths. Research chat
-uses the TypeScript OpenSecret SDK with the Responses and Conversations APIs;
-Agent Mode embeds Goose and uses the Rust OpenSecret SDK through Tauri. The
+uses the TypeScript Maple SDK with the Responses and Conversations APIs;
+Agent Mode embeds Goose and uses the Rust Maple SDK through Tauri. The
 local OpenAI-compatible proxy is a separate user-facing service.
 
-The OpenSecret SDK source and its upstream Git history live under
-[`sdk/`](../../sdk/README.md), and Maple consumes its in-tree TypeScript and Rust
-packages. The proxy source and its upstream history live under
+The Maple SDK source and its upstream Git history live under
+[`sdk/`](../../sdk/README.md). Research selects published TypeScript and Rust
+versions independently in its manifests and lockfiles, with local links
+supported during development. See the
+[SDK consumer version policy](../../docs/sdk-publishing.md#consumer-version-policy).
+The proxy source and its upstream history live under
 [`proxy/`](../../proxy/README.md); desktop Maple consumes that in-tree crate too.
 
 The source directory name does not change the shipped Maple application identity
@@ -80,9 +83,10 @@ prove billing- or flag-gated behavior. Provider credentials and administrative
 API keys belong on their servers, never in Maple.
 
 To use a local backend, follow
-[OpenSecret's own setup guide](https://github.com/OpenSecretCloud/opensecret),
-including its SQL migration step, and keep the default frontend origin unless
-you also intend to change and validate OAuth/verification callback handling.
+[OpenSecret's setup guide](../../services/opensecret/README.md#local-quick-start)
+from `services/opensecret/`, including its SQL migration step. Keep the default
+frontend origin unless you also intend to change and validate OAuth/verification
+callback handling.
 
 ## Common commands
 

--- a/docs/maple-agent-import.md
+++ b/docs/maple-agent-import.md
@@ -18,15 +18,16 @@ the source master above. The imported `apps/maple-agent` tree exactly equals
 the original root tree `feaa3bc67584d881aa5c85d742302afc52a620b4`.
 Dependency, tooling, and update adaptations follow that separate boundary.
 
-Merge this import PR with a normal merge commit. Squashing or rebasing away
-the import merge would discard the preserved upstream ancestry.
+The import merge is retained in Maple's ancestry. Its separate source parent
+preserves upstream history rather than flattening it into a squash commit.
 
 ## Integration
 
-- Use the local `maple-sdk` and `maple-proxy` packages. The GPUI SDK
-  fork is replaced by the canonical catalog API and its boolean capability
-  contract. The SDK package is renamed in tree; registry publishing remains
-  separate work.
+- The GPUI SDK fork is replaced by the canonical catalog API and its boolean capability
+  contract. Agent now selects the published `maple-sdk` independently while
+  consuming the local `maple-proxy` library. Local SDK links remain supported
+  by the [consumer version policy](sdk-publishing.md#consumer-version-policy);
+  [SDK publication](sdk-publishing.md) has its own protected manual workflow.
 - Keep the GPUI component's Cargo/Nix environment and internal `maple-gpui`
   binary name. Root commands, CI, and agent guidance route to the component.
   Linux exposes pure Nix packages; macOS uses the Nix development shell plus
@@ -62,8 +63,8 @@ follow-up work; this import does not merge, close, or rewrite them:
 | [69](https://github.com/benthecarman/maple-gpui/pull/69) | Draft `feature/cpython-codemode` | `e087b1af4eb0e4f77c036b9fff2f7904a2e9c4f0` | Separate focused port |
 | [2](https://github.com/benthecarman/maple-gpui/pull/2) | Draft `programmable-harness` | `653b95946bf391cc82998bcc6ca22fe40da577e9` | Historical conflicting draft; reassess individual slices against current master |
 
-After merging the import, direct new Agent work here and recheck each active
-branch's latest head with its author before replaying. Prefix the intended
+Direct new Agent work here and recheck each active branch's latest head with
+its author before replaying. Prefix the intended
 delta under `apps/maple-agent/` and review it against current code; do not
 blindly merge an old root-layout branch. Keep the source repository and open
 branches available until each item's disposition is recorded. Repository

--- a/docs/opensecret-import.md
+++ b/docs/opensecret-import.md
@@ -18,8 +18,8 @@ commit above. The imported subtree exactly equals the original root tree,
 `89bc0ccc1398aea4f4ece3f373a4a96d2cfd8019`. Monorepo adaptations follow this
 separate commit.
 
-Use a normal merge commit for the import PR. Squashing or rebasing away the
-import merge discards the preserved source ancestry.
+The import merge is retained in Maple's ancestry. Its separate source parent
+preserves upstream history rather than flattening it into a squash commit.
 
 Only source master is imported. Existing OpenSecret pull requests and branches
 remain in the old repository for separate review and replay under the new
@@ -60,9 +60,9 @@ and root `$develop-opensecret` / `$validate-opensecret` skills.
 
 ## Signed PCR compatibility and cutover
 
-The four imported files are byte-for-byte unchanged:
+At the import boundary, the four files were byte-for-byte unchanged:
 `pcrDev.json`, `pcrDevHistory.json`, `pcrProd.json`, and `pcrProdHistory.json`.
-Each captured history contains 145 entries. All 290 PCR0 signatures verify
+Each captured history contains 145 entries. All 290 captured PCR0 signatures verify
 against the public key pinned by both SDKs. PCR1/PCR2 are present in the JSON
 but are not covered by those signatures; this import preserves that format.
 
@@ -71,21 +71,21 @@ unarchived. Installed clients still request its raw history URLs. Retain the
 old source and outstanding branches until a separate retirement decision;
 removing that code is unnecessary for manual compatibility publication.
 
-After this import merges:
+Current TypeScript and Rust SDK defaults read the canonical histories under
+`MaplePrivacyLabs/Maple/master/services/opensecret/`. The SDK package names are
+`@mapleai/sdk` and `maple-sdk`, with independent protected
+[publishing workflows](sdk-publishing.md). Publishing a package does not upgrade
+its consumers or retire the URLs used by older clients.
 
-1. Verify the new master raw URLs for all four files return the expected bytes
-   without redirects, and validate their signatures.
-2. Use the [manual PCR compatibility procedure](../services/opensecret/docs/pcr-compatibility.md)
-   for subsequent authorized backend releases. Commit the reviewed signed
-   files in Maple, prepare an exact-byte copy into the legacy repository, and
-   verify both published locations before deploying an EIF that needs them.
-3. Switch SDK PCR history URLs in a separate change after step 1. Preserve the
-   existing signed-PCR format, pinned public key, and redirect policy.
-4. Update internal developer workspaces and deployment-builder checkouts to
-   the imported component deliberately. Existing operator hosts are not
-   migrated by merging this PR.
+For authorized backend releases, use the
+[manual PCR compatibility procedure](../services/opensecret/docs/pcr-compatibility.md):
+commit the reviewed signed files in Maple, prepare an exact-byte copy into the
+legacy repository, and verify both published locations before deploying an EIF
+that needs them. Preserve the signed-PCR format, pinned public key, and redirect
+policy. Operator builds run from `services/opensecret/`; verify the selected
+checkout and commit on each deployment host rather than assuming a merged
+source change migrated that host.
 
 GitHub does not sign PCR entries, publish EIFs, or deploy OpenSecret here. The
-copy helper does not commit or push. SDK package renaming/publishing, Sigstore,
-and the legacy compatibility sunset remain separate decisions. There is no
-automatic expiry of the legacy files.
+copy helper does not commit or push. Sigstore and the legacy compatibility
+sunset remain separate decisions. There is no automatic expiry of the legacy files.

--- a/docs/pages-deployments.md
+++ b/docs/pages-deployments.md
@@ -3,17 +3,20 @@
 Maple can publish prebuilt static assets to the existing Cloudflare Pages project
 `maple` (`maple-ca8.pages.dev`). Production remains `trymaple.ai`; its production
 branch remains `pages-production`. This does not move DNS, the `www` marketing
-site, or the updater Worker. The new path does not need a Cloudflare GitHub App.
+site, or the updater Worker. This path does not need a Cloudflare GitHub App.
 Cloudflare supports Wrangler uploads to an existing Git-integrated project after
 automatic builds are disabled; this does not convert the project's type.
 See [Cloudflare's Git integration guidance](https://developers.cloudflare.com/pages/configuration/git-integration/#disable-automatic-deployments).
 
-Merging these workflows does not enable publication. Both repository variables
+Both repository variables
 `MAPLE_PAGES_PREVIEW_ENABLED` and `MAPLE_PAGES_PRODUCTION_ENABLED` must equal the
-literal string `true` to enable their respective jobs. Missing/false variables
-leave the existing Cloudflare integration and legacy production promoter in use.
-Changing flags, secrets, Cloudflare settings, or production needs an authorized
-operator action; this guide is preparation, not evidence of a completed cutover.
+literal string `true` to enable their respective jobs. Keep both owned publishers
+enabled with Cloudflare's native automatic builds disabled. A missing/false
+variable disables its owned publisher; it does not
+reenable Cloudflare's native builds. A false production flag also reactivates
+the legacy GitHub branch promoter, as described under recovery below. Changing
+flags, secrets, Cloudflare settings, or production needs an authorized operator
+action; merging source alone does not change those settings.
 
 ## Build and destination contract
 
@@ -106,7 +109,10 @@ trust in the application being previewed.
    The new path reports GitHub deployments, workflow results, and a PR preview
    comment; it does not impersonate the old Cloudflare App check.
 
-## Staged activation before the repository transfer
+## Staged activation
+
+Use this sequence when configuring the publishers or deliberately repeating a
+cutover. Routine previews and releases use the build/destination contract above.
 
 1. Run offline validation, then merge the reviewed implementation with both flags
    absent/false. Retain evidence of the current production deployment.
@@ -127,10 +133,9 @@ trust in the application being previewed.
    release's existing artifact. No new Release or native rebuild is required.
    Verify deployment SHA, active canonical deployment ID, production ref, and
    browser production settings/PCR history; exercise login and chat.
-6. After this evidence passes, amend the organization-move runbook in its owning
-   repository to replace its earlier replacement-project/domain-cutover plan.
-   Transfer separately, then verify the new organization's runner/environment
-   access and publication. This PR does not edit that external runbook or transfer.
+6. Record the deployment and smoke-test evidence in the owning operations
+   runbook. After any repository transfer, separately verify the destination
+   organization's runner/environment access and publisher repository identity.
 
 ## Verification and recovery
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -159,7 +159,7 @@ nix develop --no-update-lock-file -c bash -lc '
   cd rust
   cargo fmt --all -- --check
   cargo clippy --locked --all-targets --all-features -- -D warnings
-  cargo test --locked --all-features
+  cargo test --locked --all-features --lib
   cargo doc --locked --no-deps --all-features
 '
 ```

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -1,8 +1,9 @@
 # Maple Rust SDK
 
-This source lives under Maple's `sdk/rust/` directory. Desktop Maple and
-Maple's in-tree `proxy/` consume it through versioned path dependencies, while
-crates.io publishing remains an independent compatibility surface.
+This source lives under Maple's `sdk/rust/` directory. Research desktop,
+Maple Agent, and the proxy select published versions independently; local links
+remain supported for development. See the
+[consumer version policy](../../docs/sdk-publishing.md#consumer-version-policy).
 
 Maple Rust SDK for the OpenSecret backend: secure AI APIs, encrypted sessions, and Nitro attestation.
 
@@ -17,9 +18,8 @@ Maple Rust SDK for the OpenSecret backend: secure AI APIs, encrypted sessions, a
 
 ## Installation
 
-`maple-sdk` is the intended replacement for the `opensecret` crate. Registry
-ownership and first publication are pending; this checkout uses local path
-dependencies. After publication, add to your `Cargo.toml`:
+`maple-sdk` is the published replacement for the `opensecret` crate. Add it to
+your `Cargo.toml`:
 
 ```toml
 [dependencies]

--- a/services/opensecret/README.md
+++ b/services/opensecret/README.md
@@ -100,9 +100,10 @@ PCRs solely to clear ordinary pull-request CI.
 The PCR files retain their existing names and signed format. Follow
 [`docs/pcr-compatibility.md`](docs/pcr-compatibility.md) for validation and manual
 publication of identical bytes to the legacy `OpenSecretCloud/opensecret`
-repository. Its existing raw URLs keep installed clients working; SDK URL
-changes require a separate, verified cutover after the new canonical files
-are available on Maple's master branch.
+repository. Current Maple SDK defaults read the canonical histories under
+`MaplePrivacyLabs/Maple/master/services/opensecret/`; the legacy raw URLs
+remain available for older installed clients. Keep both locations synchronized
+through the manual compatibility procedure.
 
 See [`docs/nitro-deploy.md`](docs/nitro-deploy.md) for operator procedures.
 Changing PCR references or KMS policy, copying artifacts, starting or stopping

--- a/services/opensecret/docs/PCR_VERIFICATION.md
+++ b/services/opensecret/docs/PCR_VERIFICATION.md
@@ -2,6 +2,13 @@
 
 This document describes the PCR (Platform Configuration Register) verification system used to validate Nitro Enclave measurements.
 
+For Maple operations, follow the [manual PCR compatibility procedure](pcr-compatibility.md).
+It preserves the existing verification key and publishes reviewed signed files
+to both the monorepo and the legacy repository before a deployment needs them.
+The examples below explain the format and an independent deployment's initial
+setup; generating a new key is not part of routine Maple PCR updates. The SDKs
+already implement verification, so clients should use their supported APIs.
+
 ## Overview
 
 The system uses an append-only history of signed PCR measurements that allows the frontend to verify enclave measurements even when they're not in the default list. This provides:

--- a/services/updates/README.md
+++ b/services/updates/README.md
@@ -17,9 +17,17 @@ The live pointer is ignored by git and must not be committed. The protected
 `Publish updater metadata` GitHub Actions workflow downloads the current stable
 GitHub Release's `latest.json`, verifies its GitHub digest and Worker schema,
 deploys it, and confirms that the public endpoint serves the exact same bytes.
-The first run also creates the `updates.trymaple.ai` Custom Domain and its DNS and
-TLS configuration. Publication is manual until the release workflow is connected
-in a later phase. Do not use a local Wrangler login for production deployment.
+The workflow runs after a successful stable Maple `Release` run and can also
+be dispatched from `master` to republish the current stable release. It ensures
+the `updates.trymaple.ai` Custom Domain targets the `maple-updates` Worker.
+SDK publication and Agent CI do not trigger this workflow. Do not use a local
+Wrangler login for production deployment.
+
+During the repository-transfer transition, keep the retained `v3.3.10` metadata
+serving until the next normal Maple release generates new-owner asset URLs.
+Do not manually republish that old metadata: the publisher now validates
+`MaplePrivacyLabs/Maple` release URLs. See the
+[release checkpoint](../../.agents/skills/release-maple/SKILL.md#repository-transfer-checkpoint).
 
 ## Development
 


### PR DESCRIPTION
Current setup and component documentation still described SDK publication, local dependency wiring, and parts of the repository cutover as future work. Refresh those instructions to match the completed imports, published SDK defaults, optional local development links, and manual PCR compatibility process.

The Pages and updater guides now describe their existing release triggers and recovery controls, including the retained v3.3.10 updater hold. Historical notes, import SHAs, compatibility URLs, and backend naming remain intact. This changes Markdown only; runtime code, dependencies, and publisher settings are unchanged.

Validation: 92 relative documentation links and new anchors checked; three modified Skills passed validation; independent source review found no material issues. The normal commit hook passed frontend formatting, build, and all 818 tests. The updater checkpoint link resolves to the existing release guide.
