### PR TITLE
Remove deprecated GLM 5.2 and default Powerful to GLM 5.3

### DIFF
--- a/apps/maple-agent/crates/maple-agent/src/agent.rs
+++ b/apps/maple-agent/crates/maple-agent/src/agent.rs
@@ -94,8 +94,9 @@ use web_permission::{
 };
 use web_tools::WebToolState;
 
-const DEFAULT_AGENT_MODEL: &str = "glm-5-2";
+const DEFAULT_AGENT_MODEL: &str = "glm-5-3";
 const LEGACY_AGENT_DEFAULT_MODEL: &str = "auto:powerful";
+const PREVIOUS_RECOMMENDED_AGENT_MODEL: &str = "glm-5-2";
 const DEFAULT_GOOSE_MODE: &str = "smart_approve";
 // Keep Goose on its ActionRequired path so Maple can apply the currently selected
 // policy at every tool boundary, including when the user changes it mid-run.
@@ -8862,7 +8863,9 @@ fn load_agent_config_file(path: &Path) -> Result<AgentConfig, anyhow::Error> {
 
 fn migrate_agent_config(config: &mut AgentConfig) -> bool {
     let mut changed = false;
-    if config.default_model == LEGACY_AGENT_DEFAULT_MODEL {
+    if config.default_model == LEGACY_AGENT_DEFAULT_MODEL
+        || config.default_model == PREVIOUS_RECOMMENDED_AGENT_MODEL
+    {
         config.default_model = default_agent_model();
         changed = true;
     }
@@ -14237,8 +14240,23 @@ mod tests {
     }
 
     #[test]
+    fn previous_glm_5_2_agent_default_migrates_to_glm_5_3() {
+        let mut config = AgentConfig {
+            default_project_root: Some("/tmp/project".to_string()),
+            default_model: PREVIOUS_RECOMMENDED_AGENT_MODEL.to_string(),
+            mcp_servers: Vec::new(),
+            project_trust: Vec::new(),
+            removed_project_roots: Vec::new(),
+        };
+
+        assert!(migrate_agent_config(&mut config));
+        assert_eq!(config.default_model, DEFAULT_AGENT_MODEL);
+        assert!(!migrate_agent_config(&mut config));
+    }
+
+    #[test]
     fn explicit_agent_model_choices_are_not_migrated() {
-        for model in ["kimi-k2-6", "auto:quick", "glm-5-2", "gemma-3-27b"] {
+        for model in ["kimi-k2-6", "auto:quick", "glm-5-3", "gemma-3-27b"] {
             let mut config = AgentConfig {
                 default_project_root: None,
                 default_model: model.to_string(),

--- a/apps/maple-research/frontend/src/components/PromoDialog.tsx
+++ b/apps/maple-research/frontend/src/components/PromoDialog.tsx
@@ -21,7 +21,7 @@ interface PromoDialogProps {
 const PROMO_BENEFITS = [
   {
     icon: <Cpu className="h-4 w-4" />,
-    text: "Powerful AI models including Gemma 4 31B, GLM 5.2, and Kimi K2.6"
+    text: "Powerful AI models including Gemma 4 31B, GLM 5.3, and Kimi K2.6"
   },
   {
     icon: <Image className="h-4 w-4" />,

--- a/apps/maple-research/frontend/src/components/UpgradePromptDialog.tsx
+++ b/apps/maple-research/frontend/src/components/UpgradePromptDialog.tsx
@@ -158,7 +158,7 @@ export function UpgradePromptDialog({
           : isPro
             ? [
                 "10x more monthly messages with Max plan",
-                "Access to all AI models including GLM 5.2 and Kimi K2.6",
+                "Access to all AI models including GLM 5.3 and Kimi K2.6",
                 "Highest priority during peak times",
                 "Maximum rate limits for power users",
                 "Or purchase extra credits to keep chatting now"
@@ -206,7 +206,7 @@ export function UpgradePromptDialog({
         requiredPlan: "Pro",
         benefits: [
           "All models run in secure, encrypted environments",
-          "Access to GLM 5.2, Kimi K2.6, and the full model lineup",
+          "Access to GLM 5.3, Kimi K2.6, and the full model lineup",
           "OpenAI GPT-OSS, Gemma, and other advanced models",
           "Higher token limits for longer conversations",
           "Priority access to new models as they launch"
@@ -253,7 +253,7 @@ export function UpgradePromptDialog({
                 {isFreeTier
                   ? "Plus access to powerful models, image & document processing, and more"
                   : isPro
-                    ? "Plus access to GLM 5.2, Kimi K2.6, 10x more usage, API access, and priority support"
+                    ? "Plus access to GLM 5.3, Kimi K2.6, 10x more usage, API access, and priority support"
                     : "Explore our pricing options for the best plan for your needs"}
               </p>
             </div>

--- a/apps/maple-research/frontend/src/config/pricingConfig.tsx
+++ b/apps/maple-research/frontend/src/config/pricingConfig.tsx
@@ -58,7 +58,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <X className="w-4 h-4 text-maple-error" />
       },
       {
-        text: "Paid AI models including Gemma 4 31B, GLM 5.2, and Kimi K2.6",
+        text: "Paid AI models including Gemma 4 31B, GLM 5.3, and Kimi K2.6",
         included: false,
         icon: <X className="w-4 h-4 text-maple-error" />
       },
@@ -97,7 +97,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-maple-success" />
       },
       {
-        text: "All AI models including GLM 5.2 and Kimi K2.6",
+        text: "All AI models including GLM 5.3 and Kimi K2.6",
         included: true,
         icon: <Check className="w-4 h-4 text-maple-success" />
       },
@@ -151,7 +151,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-maple-success" />
       },
       {
-        text: "All AI models including GLM 5.2 and Kimi K2.6",
+        text: "All AI models including GLM 5.3 and Kimi K2.6",
         included: true,
         icon: <Check className="w-4 h-4 text-maple-success" />
       },
@@ -214,7 +214,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-maple-success" />
       },
       {
-        text: "All AI models including GLM 5.2 and Kimi K2.6",
+        text: "All AI models including GLM 5.3 and Kimi K2.6",
         included: true,
         icon: <Check className="w-4 h-4 text-maple-success" />
       },

--- a/services/opensecret/src/inference.rs
+++ b/services/opensecret/src/inference.rs
@@ -317,14 +317,14 @@ mod tests {
         let intent = InferenceIntent::new(
             Uuid::nil(),
             AUTO_POWERFUL_MODEL_ID,
-            "glm-5-2",
+            "glm-5-3",
             ModelPlan::Paid,
             InferenceSurface::Responses,
             WorkloadClass::Interactive,
         );
 
         assert_eq!(intent.requested_model_id, AUTO_POWERFUL_MODEL_ID);
-        assert_eq!(intent.public_model_id, "glm-5-2");
+        assert_eq!(intent.public_model_id, "glm-5-3");
         assert_eq!(intent.selection_mode, ModelSelectionMode::AutoPowerful);
         assert!(intent.selection_mode.is_auto());
     }
@@ -348,8 +348,8 @@ mod tests {
     fn executions_and_attempts_keep_parent_ids_and_get_unique_ids() {
         let intent = InferenceIntent::new(
             Uuid::nil(),
-            "glm-5-2",
-            "glm-5-2",
+            "glm-5-3",
+            "glm-5-3",
             ModelPlan::Paid,
             InferenceSurface::Responses,
             WorkloadClass::Interactive,

--- a/services/opensecret/src/inference/health.rs
+++ b/services/opensecret/src/inference/health.rs
@@ -1832,11 +1832,10 @@ mod tests {
     fn tinfoil_glm_models_probe_independently() {
         let state = ShadowHealthState::with_policy(test_policy());
         let start = Instant::now();
-        let legacy = route(ProviderId::Tinfoil, "glm-5-2", "glm-5-2");
         let base = route(ProviderId::Tinfoil, "glm-5-3", "glm-5-3");
         let flash = route(ProviderId::Tinfoil, "glm-5-3-flash", "glm-5-3-flash");
 
-        for route in [&legacy, &base, &flash] {
+        for route in [&base, &flash] {
             state.observe_terminal_at(
                 &failed(
                     route.clone(),
@@ -1850,20 +1849,11 @@ mod tests {
         }
 
         let boundary = start + Duration::from_secs(4);
-        let legacy_probe = expect_probe(state.try_claim_probe_at(&legacy.route_key(), boundary));
         let base_probe = expect_probe(state.try_claim_probe_at(&base.route_key(), boundary));
         let flash_probe = expect_probe(state.try_claim_probe_at(&flash.route_key(), boundary));
 
-        assert_eq!(legacy_probe.claim_count(), 1);
         assert_eq!(base_probe.claim_count(), 1);
         assert_eq!(flash_probe.claim_count(), 1);
-        assert!(matches!(
-            state
-                .snapshot_at(&legacy.route_key(), boundary)
-                .unwrap()
-                .rate_limit_capacity,
-            ShadowDisposition::ProbeInFlight { .. }
-        ));
         assert!(matches!(
             state
                 .snapshot_at(&base.route_key(), boundary)

--- a/services/opensecret/src/inference_planning.rs
+++ b/services/opensecret/src/inference_planning.rs
@@ -268,8 +268,7 @@ fn stable_account_bucket(account_uuid: uuid::Uuid) -> u8 {
 mod tests {
     use super::*;
     use crate::model_config::{
-        ModelPlan, AUTO_POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID, GLM_5_3_FLASH_MODEL_ID,
-        GLM_5_3_MODEL_ID,
+        ModelPlan, AUTO_POWERFUL_MODEL_ID, GLM_5_3_FLASH_MODEL_ID, GLM_5_3_MODEL_ID,
     };
     use crate::provider_registry::{ProviderId, PROVIDER_REGISTRY};
     use uuid::Uuid;
@@ -287,7 +286,7 @@ mod tests {
 
     #[test]
     fn planner_uses_resolved_public_model_without_resolving_auto_again() {
-        let intent = intent(AUTO_POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID);
+        let intent = intent(AUTO_POWERFUL_MODEL_ID, GLM_5_3_FLASH_MODEL_ID);
         let plan = plan_completion_route(
             &PROVIDER_REGISTRY,
             RoutePlanningInput {
@@ -298,8 +297,8 @@ mod tests {
         .expect("shadow route");
 
         assert_eq!(intent.requested_model_id, AUTO_POWERFUL_MODEL_ID);
-        assert_eq!(plan.selected.public_model_id, GLM_5_2_MODEL_ID);
-        assert_eq!(plan.selected.provider_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(plan.selected.public_model_id, GLM_5_3_FLASH_MODEL_ID);
+        assert_eq!(plan.selected.provider_model_id, GLM_5_3_FLASH_MODEL_ID);
         assert_eq!(plan.selected.provider, ProviderId::Tinfoil);
         assert_eq!(plan.selected.bucket, None);
         assert_eq!(plan.decision, PlanDecision::FixedRoute);

--- a/services/opensecret/src/model_config.rs
+++ b/services/opensecret/src/model_config.rs
@@ -114,10 +114,9 @@ pub const DEFAULT_TOP_P: f32 = 1.0;
 pub const AUTO_QUICK_MODEL_ID: &str = "auto:quick";
 pub const AUTO_POWERFUL_MODEL_ID: &str = "auto:powerful";
 pub const QUICK_MODEL_ID: &str = "gpt-oss-120b";
-pub const GLM_5_2_MODEL_ID: &str = "glm-5-2";
 pub const GLM_5_3_MODEL_ID: &str = "glm-5-3";
 pub const GLM_5_3_FLASH_MODEL_ID: &str = "glm-5-3-flash";
-pub const POWERFUL_MODEL_ID: &str = GLM_5_2_MODEL_ID;
+pub const POWERFUL_MODEL_ID: &str = GLM_5_3_MODEL_ID;
 pub const KIMI_K3_MODEL_ID: &str = "kimi-k3";
 pub const KIMI_K2_6_MODEL_ID: &str = "kimi-k2-6";
 pub const DEEPSEEK_V4_FLASH_MODEL_ID: &str = "deepseek-v4-flash";
@@ -620,20 +619,6 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
     .with_catalog_provider("continuum", "glm-5.3")
     .with_catalog_metadata(ModelCatalogMetadata::new(&["text"], &["text"], None, None)),
     ModelConfigEntry::new(
-        GLM_5_2_MODEL_ID,
-        "GLM 5.2",
-        "GLM 5.2",
-        "Long-horizon pro reasoning model.",
-        ModelAccessTier::Pro,
-        ModelCapabilities::chat(true, false),
-        &["Reasoning"],
-        true,
-        true,
-        false,
-        60,
-        393_216,
-    ),
-    ModelConfigEntry::new(
         DEEPSEEK_V4_FLASH_MODEL_ID,
         "DeepSeek V4 Flash",
         "DeepSeek V4 Flash",
@@ -908,13 +893,12 @@ mod tests {
         assert_eq!(model_context_window("gpt-oss-safeguard-120b"), 131_072);
         assert_eq!(model_context_window("kimi-k2-6"), 262_144);
         assert_eq!(model_context_window("gemma4-31b"), 262_144);
-        assert_eq!(model_context_window("glm-5-2"), 393_216);
         assert_eq!(model_context_window("glm-5-3"), 262_144);
         assert_eq!(model_context_window("glm-5-3-flash"), 1_048_576);
         assert_eq!(model_context_window("kimi-k3"), 262_144);
         assert_eq!(model_context_window("deepseek-v4-flash"), 1_048_576);
         assert_eq!(model_context_window(AUTO_QUICK_MODEL_ID), 131_072);
-        assert_eq!(model_context_window(AUTO_POWERFUL_MODEL_ID), 393_216);
+        assert_eq!(model_context_window(AUTO_POWERFUL_MODEL_ID), 262_144);
     }
 
     #[test]
@@ -925,7 +909,6 @@ mod tests {
             "gpt-oss-safeguard-120b",
             "kimi-k2-6",
             "gemma4-31b",
-            "glm-5-2",
             "glm-5-3",
             "glm-5-3-flash",
             "kimi-k3",
@@ -1090,18 +1073,18 @@ mod tests {
 
     #[test]
     fn test_model_alias_targets_are_selected_by_plan() {
-        assert_eq!(POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID);
+        assert_eq!(POWERFUL_MODEL_ID, GLM_5_3_MODEL_ID);
 
         let free = ModelAliasTargets::for_plan(ModelPlan::Free);
         assert_eq!(free.resolve(AUTO_QUICK_MODEL_ID), QUICK_MODEL_ID);
-        assert_eq!(free.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_2_MODEL_ID);
+        assert_eq!(free.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_3_MODEL_ID);
 
         let paid = ModelAliasTargets::for_plan(ModelPlan::Paid);
         assert_eq!(
             paid.resolve(AUTO_QUICK_MODEL_ID),
             DEEPSEEK_V4_FLASH_MODEL_ID
         );
-        assert_eq!(paid.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_2_MODEL_ID);
+        assert_eq!(paid.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_3_MODEL_ID);
         assert_eq!(paid.resolve(KIMI_K3_MODEL_ID), KIMI_K3_MODEL_ID);
     }
 
@@ -1133,10 +1116,10 @@ mod tests {
                 assert_eq!(targets.resolve(model), model, "plan={plan:?}");
                 assert_eq!(resolve_public_model_id(targets.resolve(model)), Some(model));
             }
-            assert_eq!(targets.resolve(GLM_5_2_MODEL_ID), GLM_5_2_MODEL_ID);
+            assert_eq!(targets.resolve(GLM_5_3_MODEL_ID), GLM_5_3_MODEL_ID);
             assert_eq!(
-                resolve_completion_model_id(targets.resolve(GLM_5_2_MODEL_ID)),
-                Some(GLM_5_2_MODEL_ID)
+                resolve_completion_model_id(targets.resolve(GLM_5_3_MODEL_ID)),
+                Some(GLM_5_3_MODEL_ID)
             );
             assert_eq!(targets.resolve("unknown-model"), "unknown-model");
             assert_eq!(
@@ -1161,7 +1144,7 @@ mod tests {
             }
             assert_eq!(catalog["defaults"]["quick"], AUTO_QUICK_MODEL_ID);
             assert_eq!(catalog["defaults"]["powerful"], AUTO_POWERFUL_MODEL_ID);
-            assert!(has_model(&catalog, GLM_5_2_MODEL_ID));
+            assert!(!has_model(&catalog, "glm-5-2"));
             assert!(has_model(&catalog, GLM_5_3_MODEL_ID));
         }
     }
@@ -1175,7 +1158,7 @@ mod tests {
                 plan.allows_model(targets.resolve(AUTO_POWERFUL_MODEL_ID)),
                 plan.is_paid()
             );
-            for model in [GLM_5_2_MODEL_ID, GLM_5_3_MODEL_ID] {
+            for model in [GLM_5_3_MODEL_ID, GLM_5_3_FLASH_MODEL_ID] {
                 assert_eq!(plan.allows_model(targets.resolve(model)), plan.is_paid());
             }
         }
@@ -1192,21 +1175,14 @@ mod tests {
 
             let free = ModelAliasTargets::for_plan_with_overrides(ModelPlan::Free, overrides);
             assert_eq!(free.resolve(AUTO_QUICK_MODEL_ID), QUICK_MODEL_ID);
-            assert_eq!(free.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_2_MODEL_ID);
+            assert_eq!(free.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_3_MODEL_ID);
 
             let paid = ModelAliasTargets::for_plan_with_overrides(ModelPlan::Paid, overrides);
             assert_eq!(
                 paid.resolve(AUTO_QUICK_MODEL_ID),
                 DEEPSEEK_V4_FLASH_MODEL_ID
             );
-            assert_eq!(
-                paid.resolve(AUTO_POWERFUL_MODEL_ID),
-                if powerful_enabled {
-                    GLM_5_3_MODEL_ID
-                } else {
-                    GLM_5_2_MODEL_ID
-                }
-            );
+            assert_eq!(paid.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_3_MODEL_ID);
         }
 
         assert_eq!(
@@ -1256,8 +1232,8 @@ mod tests {
                 AUTO_QUICK_MODEL_ID,
                 DEEPSEEK_V4_FLASH_MODEL_ID,
             ),
-            (ModelPlan::Free, AUTO_POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID),
-            (ModelPlan::Paid, AUTO_POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID),
+            (ModelPlan::Free, AUTO_POWERFUL_MODEL_ID, GLM_5_3_MODEL_ID),
+            (ModelPlan::Paid, AUTO_POWERFUL_MODEL_ID, GLM_5_3_MODEL_ID),
         ] {
             let targets = ModelAliasTargets::for_plan(plan);
             assert_eq!(targets.resolve(selector), expected_target, "plan={plan:?}");
@@ -1272,7 +1248,6 @@ mod tests {
                 QUICK_MODEL_ID,
                 "kimi-k2-6",
                 KIMI_K3_MODEL_ID,
-                GLM_5_2_MODEL_ID,
                 GLM_5_3_MODEL_ID,
                 GLM_5_3_FLASH_MODEL_ID,
                 DEEPSEEK_V4_FLASH_MODEL_ID,
@@ -1303,7 +1278,7 @@ mod tests {
         assert_eq!(quick["target_model"], DEEPSEEK_V4_FLASH_MODEL_ID);
         assert_eq!(quick["access"], "pro");
         assert_eq!(quick["capabilities"]["vision"], false);
-        assert_eq!(powerful["target_model"], GLM_5_2_MODEL_ID);
+        assert_eq!(powerful["target_model"], GLM_5_3_MODEL_ID);
         assert_eq!(powerful["access"], "pro");
         assert_eq!(powerful["capabilities"]["vision"], false);
     }
@@ -1325,7 +1300,6 @@ mod tests {
             "gemma4-31b",
             "kimi-k3",
             "kimi-k2-6",
-            "glm-5-2",
             "glm-5-3",
             "glm-5-3-flash",
             "deepseek-v4-flash",
@@ -1436,7 +1410,7 @@ mod tests {
             .iter()
             .find(|alias| alias["id"] == AUTO_POWERFUL_MODEL_ID)
             .expect("powerful alias");
-        assert_eq!(powerful["target_model"], GLM_5_2_MODEL_ID);
+        assert_eq!(powerful["target_model"], GLM_5_3_MODEL_ID);
     }
 
     #[test]

--- a/services/opensecret/src/provider_client.rs
+++ b/services/opensecret/src/provider_client.rs
@@ -1057,7 +1057,7 @@ mod tests {
         headers.insert("x-hop", HeaderValue::from_static("remove-me"));
         headers.insert("x-request-id", HeaderValue::from_static("request-123"));
 
-        let body = br#"{"model":"glm-5-2","messages":[],"stream":true}"#.to_vec();
+        let body = br#"{"model":"glm-5-3","messages":[],"stream":true}"#.to_vec();
         let request = client
             .build_tinfoil_request(
                 &tinfoil_proxy(),
@@ -1341,7 +1341,7 @@ mod tests {
             api_key: None,
             provider_name: ProviderId::Continuum.as_str().to_string(),
         };
-        let body = Bytes::from_static(br#"{"model":"glm-5-2"}"#);
+        let body = Bytes::from_static(br#"{"model":"glm-5-3"}"#);
 
         let response = client
             .send(
@@ -1415,7 +1415,7 @@ mod tests {
             "x-opaque",
             HeaderValue::from_bytes(b"\x80raw").expect("opaque header value"),
         );
-        let body = Bytes::from_static(br#"{"model":"glm-5-2"}"#);
+        let body = Bytes::from_static(br#"{"model":"glm-5-3"}"#);
 
         let response = client
             .send(
@@ -1469,7 +1469,7 @@ mod tests {
         };
         let mut headers = HeaderMap::new();
         headers.insert("x-request-id", HeaderValue::from_static("request-123"));
-        let body = br#"{"model":"glm-5-2","messages":[],"stream":true}"#.to_vec();
+        let body = br#"{"model":"glm-5-3","messages":[],"stream":true}"#.to_vec();
         let template = ProviderRequest::new(
             Method::POST,
             "/v1/chat/completions?trace=1",
@@ -1534,7 +1534,7 @@ mod tests {
         );
         headers.insert("x-hop", HeaderValue::from_static("remove-me"));
         headers.insert("x-request-id", HeaderValue::from_static("request-123"));
-        let body = br#"{"model":"glm-5-2","messages":[],"stream":true}"#.to_vec();
+        let body = br#"{"model":"glm-5-3","messages":[],"stream":true}"#.to_vec();
 
         let response = client
             .send(
@@ -1638,7 +1638,6 @@ mod tests {
             [
                 "doc-upload",
                 "gemma4-31b",
-                "glm-5-2",
                 "gpt-oss-120b",
                 "gpt-oss-safeguard-120b",
                 "kimi-k2-6",
@@ -1653,7 +1652,7 @@ mod tests {
             ]
         );
 
-        let completion_body = br#"{"model":"glm-5-2","messages":[{"role":"user","content":"Reply with exactly: parity-ok"}],"temperature":0,"max_tokens":32,"stream":false}"#.to_vec();
+        let completion_body = br#"{"model":"gpt-oss-120b","messages":[{"role":"user","content":"Reply with exactly: parity-ok"}],"temperature":0,"max_tokens":32,"stream":false}"#.to_vec();
         let completion = client
             .send(
                 &provider,
@@ -1679,12 +1678,12 @@ mod tests {
         let completion: serde_json::Value =
             serde_json::from_slice(&completion_response_body).unwrap();
         assert_eq!(completion["object"], "chat.completion");
-        assert_eq!(completion["model"], "glm-5-2");
+        assert_eq!(completion["model"], "gpt-oss-120b");
         assert_eq!(completion["choices"][0]["message"]["content"], "parity-ok");
         assert!(completion["usage"]["prompt_tokens"].is_number());
         assert!(completion["usage"]["completion_tokens"].is_number());
 
-        let stream_body = br#"{"model":"glm-5-2","messages":[{"role":"user","content":"Reply with exactly: parity-stream-ok"}],"temperature":0,"max_tokens":32,"stream":true,"stream_options":{"include_usage":true}}"#.to_vec();
+        let stream_body = br#"{"model":"gpt-oss-120b","messages":[{"role":"user","content":"Reply with exactly: parity-stream-ok"}],"temperature":0,"max_tokens":32,"stream":true,"stream_options":{"include_usage":true}}"#.to_vec();
         let stream = client
             .send(
                 &provider,
@@ -1724,7 +1723,7 @@ mod tests {
         for data in &data_frames[..data_frames.len() - 1] {
             let frame: serde_json::Value = serde_json::from_str(data).unwrap();
             assert_eq!(frame["object"], "chat.completion.chunk");
-            assert_eq!(frame["model"], "glm-5-2");
+            assert_eq!(frame["model"], "gpt-oss-120b");
             saw_usage |= frame.get("usage").is_some_and(|usage| !usage.is_null());
             json_frames += 1;
         }

--- a/services/opensecret/src/provider_registry.rs
+++ b/services/opensecret/src/provider_registry.rs
@@ -6,8 +6,8 @@
 //! separate Router v1 configuration.
 
 use crate::model_config::{
-    DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_2_MODEL_ID, GLM_5_3_FLASH_MODEL_ID, GLM_5_3_MODEL_ID,
-    KIMI_K2_6_MODEL_ID, KIMI_K3_MODEL_ID, QUICK_MODEL_ID,
+    DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_3_FLASH_MODEL_ID, GLM_5_3_MODEL_ID, KIMI_K2_6_MODEL_ID,
+    KIMI_K3_MODEL_ID, QUICK_MODEL_ID,
 };
 
 pub(crate) const SHADOW_ROUTING_POLICY_VERSION: &str = "routing-v2-weighted-v2";
@@ -145,15 +145,6 @@ const KIMI_K2_6_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     enabled: true,
 }];
 
-const GLM_5_2_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
-    provider: ProviderId::Tinfoil,
-    provider_model_id: GLM_5_2_MODEL_ID,
-    response_model_id: GLM_5_2_MODEL_ID,
-    rate_limit_scope: RateLimitScope::ProviderModel,
-    weight: 100,
-    enabled: true,
-}];
-
 const GLM_5_3_ROUTES: &[ModelRouteSpec] = &[
     ModelRouteSpec {
         provider: ProviderId::Continuum,
@@ -225,10 +216,6 @@ const COMPLETION_MODELS: &[CompletionModelSpec] = &[
     CompletionModelSpec {
         public_model_id: KIMI_K2_6_MODEL_ID,
         routes: KIMI_K2_6_ROUTES,
-    },
-    CompletionModelSpec {
-        public_model_id: GLM_5_2_MODEL_ID,
-        routes: GLM_5_2_ROUTES,
     },
     CompletionModelSpec {
         public_model_id: GLM_5_3_MODEL_ID,
@@ -310,7 +297,6 @@ mod tests {
                 "gemma4-31b",
                 KIMI_K3_MODEL_ID,
                 KIMI_K2_6_MODEL_ID,
-                GLM_5_2_MODEL_ID,
                 GLM_5_3_MODEL_ID,
                 GLM_5_3_FLASH_MODEL_ID,
                 DEEPSEEK_V4_FLASH_MODEL_ID,
@@ -375,12 +361,6 @@ mod tests {
                     ProviderId::Continuum,
                     "kimi-k2.6",
                     KIMI_K2_6_MODEL_ID
-                ),
-                (
-                    GLM_5_2_MODEL_ID,
-                    ProviderId::Tinfoil,
-                    GLM_5_2_MODEL_ID,
-                    GLM_5_2_MODEL_ID
                 ),
                 (
                     GLM_5_3_MODEL_ID,
@@ -462,8 +442,8 @@ mod tests {
                 && *model == GLM_5_3_FLASH_MODEL_ID
                 && *scope == RateLimitScope::ProviderModel
         }));
-        assert!(!scopes.iter().any(|(provider, model, _)| {
-            *provider == ProviderId::Continuum && *model == "glm-5.2"
-        }));
+        assert!(!scopes
+            .iter()
+            .any(|(_, model, _)| { *model == "glm-5-2" || *model == "glm-5.2" }));
     }
 }

--- a/services/opensecret/src/provider_routing.rs
+++ b/services/opensecret/src/provider_routing.rs
@@ -7,9 +7,7 @@ use crate::inference_planning::{
     plan_completion_route, ConfiguredProviders, ProviderPreference, RoutePlan, RoutePlanningError,
     RoutePlanningInput,
 };
-use crate::model_config::{
-    resolve_completion_model_id, resolve_public_model_id, GLM_5_2_MODEL_ID, GLM_5_3_MODEL_ID,
-};
+use crate::model_config::{resolve_completion_model_id, resolve_public_model_id, GLM_5_3_MODEL_ID};
 use crate::os_flags::GLM_5_3_TINFOIL_FLAG_KEY;
 use crate::provider_registry::{
     ProviderId, ProviderRegistry, RouteSelectionSource, PROVIDER_REGISTRY,
@@ -181,14 +179,6 @@ const KIMI_K2_6_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
     requires_explicit_preference: false,
 }];
 
-const GLM_5_2_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
-    provider: ProviderId::Tinfoil,
-    provider_model_id: GLM_5_2_MODEL_ID,
-    weight: 100,
-    enabled: true,
-    requires_explicit_preference: false,
-}];
-
 const GLM_5_3_ROUTES: &[ModelProviderRoute] = &[
     ModelProviderRoute {
         provider: ProviderId::Continuum,
@@ -215,12 +205,6 @@ const MODEL_ROUTES: &[ModelRoutingConfig] = &[
         routes: KIMI_K2_6_ROUTES,
         provider_flag: None,
         default_provider: Some(ProviderId::Continuum),
-    },
-    ModelRoutingConfig {
-        public_model_id: GLM_5_2_MODEL_ID,
-        routes: GLM_5_2_ROUTES,
-        provider_flag: None,
-        default_provider: Some(ProviderId::Tinfoil),
     },
     ModelRoutingConfig {
         public_model_id: GLM_5_3_MODEL_ID,
@@ -802,8 +786,8 @@ mod tests {
     };
     use crate::model_config::{
         ModelAliasTargets, ModelPlan, PaidModelAliasOverrides, AUTO_POWERFUL_MODEL_ID,
-        AUTO_QUICK_MODEL_ID, DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_2_MODEL_ID, GLM_5_3_FLASH_MODEL_ID,
-        GLM_5_3_MODEL_ID, KIMI_K2_6_MODEL_ID, KIMI_K3_MODEL_ID, QUICK_MODEL_ID,
+        AUTO_QUICK_MODEL_ID, DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_3_FLASH_MODEL_ID, GLM_5_3_MODEL_ID,
+        KIMI_K2_6_MODEL_ID, KIMI_K3_MODEL_ID, QUICK_MODEL_ID,
     };
     use crate::os_flags::PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY;
     use std::collections::HashMap;
@@ -1096,9 +1080,9 @@ mod tests {
                 provider_preference: None,
                 continuum_available: true,
                 expected_access: false,
-                expected_public_model: GLM_5_2_MODEL_ID,
-                expected_provider: "tinfoil",
-                expected_provider_model: GLM_5_2_MODEL_ID,
+                expected_public_model: GLM_5_3_MODEL_ID,
+                expected_provider: "continuum",
+                expected_provider_model: "glm-5.3",
                 expected_source: RouteSelectionSource::DefaultProvider,
             },
             Case {
@@ -1120,9 +1104,9 @@ mod tests {
                 provider_preference: None,
                 continuum_available: true,
                 expected_access: true,
-                expected_public_model: GLM_5_2_MODEL_ID,
-                expected_provider: "tinfoil",
-                expected_provider_model: GLM_5_2_MODEL_ID,
+                expected_public_model: GLM_5_3_MODEL_ID,
+                expected_provider: "continuum",
+                expected_provider_model: "glm-5.3",
                 expected_source: RouteSelectionSource::DefaultProvider,
             },
             Case {
@@ -1136,18 +1120,6 @@ mod tests {
                 expected_provider: "tinfoil",
                 expected_provider_model: KIMI_K3_MODEL_ID,
                 expected_source: RouteSelectionSource::StaticSplit,
-            },
-            Case {
-                name: "explicit GLM default",
-                selector: GLM_5_2_MODEL_ID,
-                plan: ModelPlan::Paid,
-                provider_preference: None,
-                continuum_available: true,
-                expected_access: true,
-                expected_public_model: GLM_5_2_MODEL_ID,
-                expected_provider: "tinfoil",
-                expected_provider_model: GLM_5_2_MODEL_ID,
-                expected_source: RouteSelectionSource::DefaultProvider,
             },
             Case {
                 name: "explicit GLM 5.3 Tinfoil preference",
@@ -1619,7 +1591,6 @@ mod tests {
         let proxy_router = proxy_router_with_both_providers();
 
         for (provider, public_model, provider_model) in [
-            (ProviderId::Tinfoil, GLM_5_2_MODEL_ID, GLM_5_2_MODEL_ID),
             (
                 ProviderId::Tinfoil,
                 GLM_5_3_FLASH_MODEL_ID,
@@ -1691,47 +1662,19 @@ mod tests {
     }
 
     #[test]
-    fn test_glm_5_2_always_uses_tinfoil() {
-        let router = ProviderRouter::default();
-        let proxy_router = proxy_router_with_both_providers();
-
-        for bucket in [0, 29, 30, 69, 70, 99] {
-            let selected = router
-                .select_completion_route(&proxy_router, uuid_for_bucket(bucket), GLM_5_2_MODEL_ID)
-                .expect("route");
-
-            assert_eq!(selected.proxy.provider_name, "tinfoil");
-            assert_eq!(selected.public_model_id, GLM_5_2_MODEL_ID);
-            assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
-            assert_eq!(selected.response_model_id, GLM_5_2_MODEL_ID);
-            assert_eq!(selected.bucket, None);
-            assert_eq!(
-                selected.selection_source,
-                RouteSelectionSource::DefaultProvider
-            );
-        }
-    }
-
-    #[test]
-    fn test_glm_5_2_and_alias_have_no_provider_routing_flag() {
+    fn test_alias_and_single_provider_models_have_no_provider_routing_flag() {
         let router = ProviderRouter::default();
 
-        assert_eq!(
-            router.provider_routing_flag_for_completion_model(GLM_5_2_MODEL_ID),
-            None
-        );
-        assert_eq!(
-            router.provider_routing_flag_for_completion_model(
-                crate::model_config::AUTO_POWERFUL_MODEL_ID
-            ),
-            None
-        );
         assert_eq!(
             router.provider_routing_flag_for_completion_model("kimi-k2-6"),
             None
         );
         assert_eq!(
             router.provider_routing_flag_for_completion_model("gpt-oss-120b"),
+            None
+        );
+        assert_eq!(
+            router.provider_routing_flag_for_completion_model(GLM_5_3_FLASH_MODEL_ID),
             None
         );
     }
@@ -1750,72 +1693,6 @@ mod tests {
             flag.preference_for(true).source(),
             RouteSelectionSource::FeatureFlag
         );
-    }
-
-    #[test]
-    fn test_glm_5_2_rejects_continuum_preference_and_stays_on_tinfoil() {
-        let router = ProviderRouter::default();
-        let proxy_router = proxy_router_with_both_providers();
-
-        let selected = router
-            .select_completion_route_with_preference(
-                &proxy_router,
-                uuid_for_bucket(1),
-                GLM_5_2_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
-            )
-            .expect("route");
-
-        assert_eq!(selected.proxy.provider_name, "tinfoil");
-        assert_eq!(selected.public_model_id, GLM_5_2_MODEL_ID);
-        assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
-        assert_eq!(selected.response_model_id, GLM_5_2_MODEL_ID);
-        assert_eq!(selected.bucket, None);
-        assert_eq!(selected.selection_source, RouteSelectionSource::Fallback);
-    }
-
-    #[test]
-    fn test_generic_tinfoil_preference_selects_glm_5_2_route() {
-        let router = ProviderRouter::default();
-        let proxy_router = proxy_router_with_both_providers();
-
-        let selected = router
-            .select_completion_route_with_preference(
-                &proxy_router,
-                uuid_for_bucket(99),
-                GLM_5_2_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
-            )
-            .expect("route");
-
-        assert_eq!(selected.proxy.provider_name, "tinfoil");
-        assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
-        assert_eq!(selected.bucket, None);
-        assert_eq!(selected.selection_source, RouteSelectionSource::FeatureFlag);
-    }
-
-    #[test]
-    fn test_glm_continuum_preference_falls_back_to_tinfoil_when_unavailable() {
-        let router = ProviderRouter::default();
-        let tinfoil_only = ProxyRouter::new(
-            "https://api.openai.com".to_string(),
-            None,
-            "http://tinfoil.example.com".to_string(),
-        );
-
-        let selected = router
-            .select_completion_route_with_preference(
-                &tinfoil_only,
-                uuid_for_bucket(70),
-                GLM_5_2_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
-            )
-            .expect("route");
-
-        assert_eq!(selected.proxy.provider_name, "tinfoil");
-        assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
-        assert_eq!(selected.bucket, None);
-        assert_eq!(selected.selection_source, RouteSelectionSource::Fallback);
     }
 
     #[test]
@@ -1911,10 +1788,10 @@ mod tests {
             )
             .expect("route");
 
-        assert_eq!(selected.proxy.provider_name, "tinfoil");
-        assert_eq!(selected.public_model_id, GLM_5_2_MODEL_ID);
-        assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
-        assert_eq!(selected.response_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(selected.proxy.provider_name, "continuum");
+        assert_eq!(selected.public_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(selected.provider_model_id, "glm-5.3");
+        assert_eq!(selected.response_model_id, GLM_5_3_MODEL_ID);
         assert_eq!(selected.bucket, None);
         assert_eq!(
             selected.selection_source,

--- a/services/opensecret/src/tokens.rs
+++ b/services/opensecret/src/tokens.rs
@@ -51,13 +51,12 @@ mod tests {
         assert_eq!(model_max_ctx("gpt-oss-safeguard-120b"), 131_072);
         assert_eq!(model_max_ctx("kimi-k2-6"), 262_144);
         assert_eq!(model_max_ctx("gemma4-31b"), 262_144);
-        assert_eq!(model_max_ctx("glm-5-2"), 393_216);
         assert_eq!(model_max_ctx("glm-5-3"), 262_144);
         assert_eq!(model_max_ctx("glm-5-3-flash"), 1_048_576);
         assert_eq!(model_max_ctx("kimi-k3"), 262_144);
         assert_eq!(model_max_ctx("deepseek-v4-flash"), 1_048_576);
         assert_eq!(model_max_ctx("auto:quick"), 131_072);
-        assert_eq!(model_max_ctx("auto:powerful"), 393_216);
+        assert_eq!(model_max_ctx("auto:powerful"), 262_144);
     }
 
     #[test]

--- a/services/opensecret/src/web/openai.rs
+++ b/services/opensecret/src/web/openai.rs
@@ -4194,7 +4194,7 @@ mod tests {
             InferenceIntent::new(
                 Uuid::nil(),
                 crate::model_config::AUTO_POWERFUL_MODEL_ID,
-                "glm-5-2",
+                "glm-5-3",
                 ModelPlan::Paid,
                 InferenceSurface::Responses,
                 WorkloadClass::Interactive,
@@ -4206,9 +4206,9 @@ mod tests {
                     api_key: None,
                     provider_name: "tinfoil".to_string(),
                 },
-                public_model_id: "glm-5-2".to_string(),
-                provider_model_id: "glm-5-2".to_string(),
-                response_model_id: "glm-5-2".to_string(),
+                public_model_id: "glm-5-3".to_string(),
+                provider_model_id: "glm-5-3".to_string(),
+                response_model_id: "glm-5-3".to_string(),
                 bucket: None,
                 selection_source: crate::provider_registry::RouteSelectionSource::DefaultProvider,
             },
@@ -4221,7 +4221,7 @@ mod tests {
         let pinned = pinned_test_completion();
         let matching = ExactCompletionRoute {
             provider_name: "tinfoil".to_string(),
-            provider_model_id: "glm-5-2".to_string(),
+            provider_model_id: "glm-5-3".to_string(),
         };
         assert!(completion_route_matches_exact_constraint(
             &pinned.route,
@@ -5764,8 +5764,8 @@ mod tests {
         assert_ne!(first.execution_id, second.execution_id);
         assert_ne!(first.attempt_id, second.attempt_id);
         assert_eq!(first.route, second.route);
-        assert_eq!(first.route.public_model_id, "glm-5-2");
-        assert_eq!(first.route.provider_model_id, "glm-5-2");
+        assert_eq!(first.route.public_model_id, "glm-5-3");
+        assert_eq!(first.route.provider_model_id, "glm-5-3");
         assert_eq!(
             pinned.intent().requested_model_id,
             crate::model_config::AUTO_POWERFUL_MODEL_ID
@@ -5785,9 +5785,9 @@ mod tests {
         let shadow = RoutePlan {
             selected: crate::inference::RouteIdentity::new(
                 ProviderId::Continuum,
-                "glm-5-2",
+                "glm-5-3",
                 "shadow-provider-model",
-                "glm-5-2",
+                "glm-5-3",
                 crate::provider_registry::RouteSelectionSource::Fallback,
                 Some(73),
             ),
@@ -5814,13 +5814,13 @@ mod tests {
         let retained = retain_active_route_after_shadow_observation(
             pinned.intent(),
             Ok(active.clone()),
-            Err(RoutePlanningError::NoEligibleRoute("glm-5-2".to_string())),
+            Err(RoutePlanningError::NoEligibleRoute("glm-5-3".to_string())),
         )
         .expect("shadow error must retain active route");
         assert_eq!(retained.identity(), active.identity());
         assert_eq!(retained.proxy, active.proxy);
 
-        let active_error = ProviderRoutingError::NoEligibleRoute("glm-5-2".to_string());
+        let active_error = ProviderRoutingError::NoEligibleRoute("glm-5-3".to_string());
         let result = retain_active_route_after_shadow_observation(
             pinned.intent(),
             Err(active_error.clone()),
@@ -6097,11 +6097,6 @@ mod tests {
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
         assert!(ensure_completion_model_access("deepseek-v4-flash", ModelPlan::Paid).is_ok());
-        assert!(matches!(
-            ensure_completion_model_access("glm-5-2", ModelPlan::Free),
-            Err(ApiError::ModelNotAvailableOnPlan)
-        ));
-        assert!(ensure_completion_model_access("glm-5-2", ModelPlan::Paid).is_ok());
         assert!(matches!(
             ensure_completion_model_access("glm-5-3", ModelPlan::Free),
             Err(ApiError::ModelNotAvailableOnPlan)
@@ -6671,7 +6666,6 @@ mod tests {
             ("tinfoil", "gpt-oss-120b"),
             ("tinfoil", "deepseek-v4-flash"),
             ("tinfoil", "kimi-k3"),
-            ("tinfoil", "glm-5-2"),
             ("tinfoil", "glm-5-3"),
             ("tinfoil", "glm-5-3-flash"),
             ("continuum", "kimi-k2-6"),

--- a/services/opensecret/src/web/responses/context_builder.rs
+++ b/services/opensecret/src/web/responses/context_builder.rs
@@ -1002,7 +1002,7 @@ mod tests {
     #[test]
     fn test_prompt_budget_uses_model_context_window() {
         assert_eq!(prompt_token_budget("llama3-3-70b"), 131_072);
-        assert_eq!(prompt_token_budget("glm-5-2"), 393_216);
+        assert_eq!(prompt_token_budget("glm-5-3"), 262_144);
         assert_eq!(prompt_token_budget("glm-5-3-flash"), 1_048_576);
     }
 
@@ -1234,11 +1234,11 @@ mod tests {
         let incoming_tokens = 2_000;
         let metadata = vec![
             context_metadata("user", 1, 1_000),
-            context_metadata("assistant", 2, 389_216),
+            context_metadata("assistant", 2, 258_144),
             context_metadata("user", 3, 1_000),
         ];
         let (needed_ids, did_truncate) =
-            determine_needed_message_ids(&metadata, "glm-5-2", 0, incoming_tokens)
+            determine_needed_message_ids(&metadata, "glm-5-3", 0, incoming_tokens)
                 .expect("select history within the full context window");
         assert!(!did_truncate);
         assert_eq!(
@@ -1252,15 +1252,15 @@ mod tests {
 
         let history = vec![
             create_chat_msg("user", "First question", Some(1_000)),
-            create_chat_msg("assistant", "Full answer", Some(389_216)),
+            create_chat_msg("assistant", "Full answer", Some(258_144)),
             create_chat_msg("user", "Follow-up", Some(1_000)),
         ];
         let (messages, history_tokens) =
-            build_prompt_from_chat_messages_with_token_reserve(history, "glm-5-2", incoming_tokens)
+            build_prompt_from_chat_messages_with_token_reserve(history, "glm-5-3", incoming_tokens)
                 .expect("build history with room reserved for the incoming message");
         assert_eq!(messages.len(), 3);
         assert_eq!(messages[1]["content"], "Full answer");
-        assert_eq!(history_tokens + incoming_tokens, 393_216);
+        assert_eq!(history_tokens + incoming_tokens, 262_144);
     }
 
     #[test]
@@ -1849,7 +1849,7 @@ mod tests {
         ];
 
         let (messages, total_tokens) =
-            build_prompt_from_chat_messages(msgs, "glm-5-2").expect("build prompt");
+            build_prompt_from_chat_messages(msgs, "glm-5-3").expect("build prompt");
 
         assert_eq!(messages[1]["role"], ROLE_ASSISTANT);
         assert_eq!(messages[1]["content"], "The answer is 42.");

--- a/services/opensecret/src/web/responses/handlers.rs
+++ b/services/opensecret/src/web/responses/handlers.rs
@@ -1120,13 +1120,13 @@ mod tests {
     #[test]
     fn test_apply_responses_model_defaults_preserves_glm_reasoning_history() {
         let mut chat_request = json!({
-            "model": "glm-5-2"
+            "model": "glm-5-3"
         });
 
         apply_responses_model_defaults(
             &mut chat_request,
-            crate::model_config::model_config("glm-5-2").responses,
-            "glm-5-2",
+            crate::model_config::model_config("glm-5-3").responses,
+            "glm-5-3",
         );
 
         assert_eq!(
@@ -1773,12 +1773,12 @@ mod tests {
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
         assert!(matches!(
-            resolve_responses_model("glm-5-2", "tinfoil", ModelPlan::Free),
+            resolve_responses_model("glm-5-3", "tinfoil", ModelPlan::Free),
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
         assert_eq!(
-            resolve_responses_model("glm-5-2", "tinfoil", ModelPlan::Paid).unwrap(),
-            "glm-5-2"
+            resolve_responses_model("glm-5-3", "tinfoil", ModelPlan::Paid).unwrap(),
+            "glm-5-3"
         );
         assert!(matches!(
             resolve_responses_model("glm-5-3", "continuum", ModelPlan::Free),
@@ -1860,7 +1860,7 @@ mod tests {
                 name: "free auto powerful",
                 plan: ModelPlan::Free,
                 selector: crate::model_config::AUTO_POWERFUL_MODEL_ID,
-                expected_model: crate::model_config::GLM_5_2_MODEL_ID,
+                expected_model: crate::model_config::GLM_5_3_MODEL_ID,
                 expected_access: false,
             },
             Case {
@@ -1874,7 +1874,7 @@ mod tests {
                 name: "paid auto powerful",
                 plan: ModelPlan::Paid,
                 selector: crate::model_config::AUTO_POWERFUL_MODEL_ID,
-                expected_model: crate::model_config::GLM_5_2_MODEL_ID,
+                expected_model: crate::model_config::GLM_5_3_MODEL_ID,
                 expected_access: true,
             },
         ];
@@ -1901,11 +1901,6 @@ mod tests {
             kimi_request["chat_template_kwargs"]["preserve_thinking"],
             true
         );
-
-        let glm = responses_request_for_model("glm-5-2");
-        let glm_request =
-            build_model_turn_request(&glm, &[json!({"role": "user", "content": "hello"})], false);
-        assert_eq!(glm_request["chat_template_kwargs"]["clear_thinking"], false);
 
         let glm_5_3 = responses_request_for_model("glm-5-3");
         let glm_5_3_request = build_model_turn_request(
@@ -1940,7 +1935,7 @@ mod tests {
             &[json!({"role": "user", "content": "hello"})],
             false,
         );
-        assert_eq!(auto_request["model"], crate::model_config::GLM_5_2_MODEL_ID);
+        assert_eq!(auto_request["model"], crate::model_config::GLM_5_3_MODEL_ID);
         assert_eq!(
             auto_request["chat_template_kwargs"]["clear_thinking"],
             false


### PR DESCRIPTION
GLM 5.2 is being deprecated. Remove it as a public catalog model and as a routed completion target in both the legacy router and router v2.

`auto:powerful` now resolves to GLM 5.3 on both plans. Router v2 already used GLM 5.3 for that alias; the default Powerful target matches it, so the paid `model-alias.paid.powerful.glm-5-3` flag is a no-op. Historical `glm-5-2` IDs still get GLM thinking-clear handling if they appear in stored conversation history, but they are no longer selectable or routable.

Maple Agent migrates saved `glm-5-2` and legacy `auto:powerful` defaults to `glm-5-3`. Research already cleared sticky `glm-5-2` preferences. Pricing and upgrade copy now advertise GLM 5.3.

Validation:

- OpenSecret `cargo fmt --all -- --check`, clippy with `-D warnings`, and `cargo test --locked --all-features`: 634 passed, 0 failed, 23 ignored.
- Pre-commit hook: frontend Prettier, production build, and 818 bun tests.

Not run: live Tinfoil probe (ignored; completions now use `gpt-oss-120b`), Maple Agent compile/tests, encrypted SDK or Maple smoke. Billing still prices historical `glm-5-2` usage events and is unchanged.