### PR TITLE
Pin maple-agent CUA SDK to upstream trycua/cua

### DIFF
--- a/apps/maple-agent/Cargo.lock
+++ b/apps/maple-agent/Cargo.lock
@@ -371,7 +371,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -382,7 +382,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2400,8 +2400,8 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-contract"
-version = "0.23.2"
-source = "git+https://github.com/AnthonyRonning/cua.git?rev=4c17c70aa920f238bcccc4f1b13375d87ef0c478#4c17c70aa920f238bcccc4f1b13375d87ef0c478"
+version = "0.28.0"
+source = "git+https://github.com/trycua/cua.git?rev=2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00#2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00"
 dependencies = [
  "schemars 1.2.2",
  "serde",
@@ -2411,8 +2411,8 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-core"
-version = "0.23.2"
-source = "git+https://github.com/AnthonyRonning/cua.git?rev=4c17c70aa920f238bcccc4f1b13375d87ef0c478#4c17c70aa920f238bcccc4f1b13375d87ef0c478"
+version = "0.28.0"
+source = "git+https://github.com/trycua/cua.git?rev=2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00#2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2427,6 +2427,7 @@ dependencies = [
  "hkdf 0.12.4",
  "hmac 0.12.1",
  "image 0.25.10",
+ "jsonschema 0.46.10",
  "libc",
  "regex",
  "regorus",
@@ -2448,8 +2449,8 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-sdk"
-version = "0.23.2"
-source = "git+https://github.com/AnthonyRonning/cua.git?rev=4c17c70aa920f238bcccc4f1b13375d87ef0c478#4c17c70aa920f238bcccc4f1b13375d87ef0c478"
+version = "0.28.0"
+source = "git+https://github.com/trycua/cua.git?rev=2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00#2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00"
 dependencies = [
  "async-trait",
  "core-foundation 0.10.0",
@@ -2470,8 +2471,8 @@ dependencies = [
 
 [[package]]
 name = "cursor-overlay"
-version = "0.23.2"
-source = "git+https://github.com/AnthonyRonning/cua.git?rev=4c17c70aa920f238bcccc4f1b13375d87ef0c478#4c17c70aa920f238bcccc4f1b13375d87ef0c478"
+version = "0.28.0"
+source = "git+https://github.com/trycua/cua.git?rev=2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00#2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00"
 dependencies = [
  "anyhow",
  "cua-driver-contract",
@@ -2839,7 +2840,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3128,7 +3129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4814,7 +4815,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6357,7 +6358,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7082,7 +7083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7320,8 +7321,8 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pip-preview"
-version = "0.23.2"
-source = "git+https://github.com/AnthonyRonning/cua.git?rev=4c17c70aa920f238bcccc4f1b13375d87ef0c478#4c17c70aa920f238bcccc4f1b13375d87ef0c478"
+version = "0.28.0"
+source = "git+https://github.com/trycua/cua.git?rev=2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00#2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -7363,14 +7364,15 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "platform-linux"
-version = "0.23.2"
-source = "git+https://github.com/AnthonyRonning/cua.git?rev=4c17c70aa920f238bcccc4f1b13375d87ef0c478#4c17c70aa920f238bcccc4f1b13375d87ef0c478"
+version = "0.28.0"
+source = "git+https://github.com/trycua/cua.git?rev=2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00#2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00"
 dependencies = [
  "anyhow",
  "ashpd",
  "async-trait",
  "atspi 0.30.0",
  "base64 0.22.1",
+ "bitflags 2.13.1",
  "calloop",
  "clipboard-rs",
  "crossbeam-channel",
@@ -7380,6 +7382,7 @@ dependencies = [
  "dirs 5.0.1",
  "enumflags2",
  "evdev",
+ "futures-util",
  "getrandom 0.4.3",
  "image 0.25.10",
  "keyring",
@@ -7390,6 +7393,8 @@ dependencies = [
  "reis",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
+ "socket2",
  "thiserror 1.0.69",
  "tiny-skia",
  "tokio",
@@ -7409,8 +7414,8 @@ dependencies = [
 
 [[package]]
 name = "platform-macos"
-version = "0.23.2"
-source = "git+https://github.com/AnthonyRonning/cua.git?rev=4c17c70aa920f238bcccc4f1b13375d87ef0c478#4c17c70aa920f238bcccc4f1b13375d87ef0c478"
+version = "0.28.0"
+source = "git+https://github.com/trycua/cua.git?rev=2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00#2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7433,11 +7438,12 @@ dependencies = [
  "objc2-foundation 0.2.2",
  "objc2-quartz-core 0.2.2",
  "pip-preview",
- "screencapturekit 6.1.0",
+ "screencapturekit 8.0.1",
  "security-framework",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "time",
  "tiny-skia",
  "tokio",
  "tokio-tungstenite 0.24.0",
@@ -7448,8 +7454,8 @@ dependencies = [
 
 [[package]]
 name = "platform-windows"
-version = "0.23.2"
-source = "git+https://github.com/AnthonyRonning/cua.git?rev=4c17c70aa920f238bcccc4f1b13375d87ef0c478#4c17c70aa920f238bcccc4f1b13375d87ef0c478"
+version = "0.28.0"
+source = "git+https://github.com/trycua/cua.git?rev=2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00#2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7916,7 +7922,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8662,7 +8668,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8720,7 +8726,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8878,9 +8884,9 @@ dependencies = [
 
 [[package]]
 name = "screencapturekit"
-version = "6.1.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d826cde3e3238feab5cd87fc73f9d0d9d1132e31d02db37e1a510401882392e9"
+checksum = "9ddaa8d6b16a2762c9a97c9a6297f04cb8ded0487e5ef02dc98b4e2bee3a26c7"
 dependencies = [
  "apple-cf",
  "apple-metal",
@@ -9431,7 +9437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9685,7 +9691,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10126,7 +10132,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10884,7 +10890,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11871,7 +11877,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/apps/maple-agent/crates/maple-agent/Cargo.toml
+++ b/apps/maple-agent/crates/maple-agent/Cargo.toml
@@ -43,11 +43,11 @@ bytes = "1"
 windows = { version = "0.62.2", features = ["Win32_System_Threading"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-# CUA's native SDK is not published to crates.io yet. Pin the exact source
-# commit that applies the Xcode 26.5 linker compatibility and embedded-host
-# main-thread restoration fixes directly on top of the 0.23.2 release so
-# Maple's embedded runtime remains reproducible.
-cua-driver-sdk = { git = "https://github.com/AnthonyRonning/cua.git", rev = "4c17c70aa920f238bcccc4f1b13375d87ef0c478", package = "cua-driver-sdk" }
+# CUA's native SDK is not published to crates.io yet. Pin the trycua/cua
+# commit that landed the Xcode 26.5 linker compatibility, embedded-host
+# main-thread restoration, and ashpd async-io backend (trycua/cua#3687)
+# so Maple's embedded runtime remains reproducible.
+cua-driver-sdk = { git = "https://github.com/trycua/cua.git", rev = "2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00", package = "cua-driver-sdk" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Ask the session bus whether the GNOME compositor helper is loaded. It is
@@ -59,7 +59,7 @@ zbus = { version = "5.19", default-features = false, features = ["blocking-api",
 # already links, so it stays on by default. PipeWire per-window capture needs
 # libpipewire and libspa headers at build time and is deliberately left off;
 # full-screen portal screenshots do not need it.
-cua-driver-sdk = { git = "https://github.com/AnthonyRonning/cua.git", rev = "4c17c70aa920f238bcccc4f1b13375d87ef0c478", package = "cua-driver-sdk", features = ["portal-input"] }
+cua-driver-sdk = { git = "https://github.com/trycua/cua.git", rev = "2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00", package = "cua-driver-sdk", features = ["portal-input"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/apps/maple-agent/crates/maple-agent/src/agent/cua.rs
+++ b/apps/maple-agent/crates/maple-agent/src/agent/cua.rs
@@ -46,7 +46,7 @@ use super::image_mediation::{
 };
 use super::web_tools::{Keep, bounded_chars};
 
-pub(super) const EMBEDDED_CUA_VERSION: &str = "0.23.2";
+pub(super) const EMBEDDED_CUA_VERSION: &str = "0.28.0";
 
 // These match Cua Driver's reviewed standard-session policy. The trusted
 // session is renewed whenever Maple prepares the task for another run.

--- a/apps/maple-agent/docs/embedded-cua.md
+++ b/apps/maple-agent/docs/embedded-cua.md
@@ -2,12 +2,13 @@
 
 Maple can expose the Cua Driver tool catalog to its embedded Goose agent
 without launching a Cua Driver daemon or an MCP child process. The macOS and
-Linux builds pin Cua's `cua-driver-sdk` source at an immutable commit directly
-on top of release `0.23.2` and create the native runtime inside the Maple
-process. The source delta fixes Cua's macOS SDK link declarations for Xcode
-26.5 and routes self-process window restoration through AppKit's main queue.
-The latter avoids an upstream `invoke_menu` crash that only exists when CUA is
-embedded inside the application whose window it restores.
+Linux builds pin Cua's `cua-driver-sdk` source at the trycua/cua commit that
+landed Xcode 26.5 linker compatibility, self-process window restoration on the
+AppKit main queue, and the ashpd `async-io` backend (`trycua/cua#3687`) and
+create the native runtime inside the Maple process. Self-process restoration
+avoids an `invoke_menu` crash that only exists when CUA is embedded inside the
+application whose window it restores. The Linux backend selection matches
+GPUI's `async-io` stack so the two compile together.
 
 Which platforms host the runtime is decided in one place, by the `embedded_cua`
 configuration flag that `crates/maple-agent/build.rs` sets. Adding a platform

--- a/apps/maple-agent/flake.nix
+++ b/apps/maple-agent/flake.nix
@@ -102,7 +102,7 @@
                 "xim-ctext-0.3.0" = "sha256-pRT4Sz1JU9ros47/7pmIW9kosWOGMOItcnNd+VrvnpE=";
                 "zed-font-kit-0.14.1-zed" = "sha256-KXygi0olNQi5yM8eaJVykNDtbPMDjT+cWPBF8UrtXR4=";
                 "zed-scap-0.0.8-zed" = "sha256-BihiQHlal/eRsktyf0GI3aSWsUCW7WcICMsC2Xvb7kw=";
-                "cua-driver-sdk-0.23.2" = "sha256-769sMyUJU32sjNKQ0ozmwiEEh8rTHgu2ikqdoLrHuZE=";
+                "cua-driver-sdk-0.28.0" = "sha256-jiAlbvolcowWSmenp7TtnJu7rn6W6qe8bj3fgWdemN8=";
                 "goose-1.47.0" = "sha256-STodRA8jEWr5pmOxOKlNGzmg5h8s4GWZWtOYqfaJTLM=";
               };
             };


### PR DESCRIPTION
## Summary

Point the GPUI Maple Agent's embedded CUA runtime at the upstream commit that landed in [trycua/cua#3687](https://github.com/trycua/cua/pull/3687) instead of the private `AnthonyRonning/cua` fork.

That commit includes the Xcode 26.5 linker fix, AppKit main-queue self-window restore, and the Linux `ashpd` `async-io` backend that GPUI needs. The SDK crate is now `cua-driver-sdk` 0.28.0 at `2dbc1c2cfbee5d25c9cea2dc37db80b98d4f9b00`.

Research/Tauri does not consume this SDK and is unchanged.

## Validation

- `nix develop --no-update-lock-file -c cargo build -p maple-gpui --locked` in `apps/maple-agent` succeeded on this macOS checkout.
- Not run, not tested (per request).

## Notes

- Workspace: `/Users/admin/workspaces/cua-sdk` from current `origin/master` (`ca1f7dc4`).
- Nix `cargoLock.outputHashes` updated for `cua-driver-sdk-0.28.0`.
