### PR TITLE
Add DeepSeek V4.1 Flash

### DIFF
--- a/services/opensecret/src/model_config.rs
+++ b/services/opensecret/src/model_config.rs
@@ -120,6 +120,7 @@ pub const POWERFUL_MODEL_ID: &str = GLM_5_3_MODEL_ID;
 pub const KIMI_K3_MODEL_ID: &str = "kimi-k3";
 pub const KIMI_K2_6_MODEL_ID: &str = "kimi-k2-6";
 pub const DEEPSEEK_V4_FLASH_MODEL_ID: &str = "deepseek-v4-flash";
+pub const DEEPSEEK_V4_1_FLASH_MODEL_ID: &str = "deepseek-v4-1-flash";
 
 const FREE_MODEL_ALIAS_TARGETS: ModelAliasTargets = ModelAliasTargets {
     quick: QUICK_MODEL_ID,
@@ -619,6 +620,26 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
     .with_catalog_provider("continuum", "glm-5.3")
     .with_catalog_metadata(ModelCatalogMetadata::new(&["text"], &["text"], None, None)),
     ModelConfigEntry::new(
+        DEEPSEEK_V4_1_FLASH_MODEL_ID,
+        "DeepSeek V4.1 Flash",
+        "DeepSeek V4.1 Flash",
+        "Long-context multimodal reasoning and tool-use model.",
+        ModelAccessTier::Pro,
+        ModelCapabilities::chat(true, true),
+        &["New", "Reasoning"],
+        true,
+        true,
+        false,
+        65,
+        1_048_576,
+    )
+    .with_catalog_metadata(ModelCatalogMetadata::new(
+        &["text", "image"],
+        &["text"],
+        Some("552B"),
+        Some("16B"),
+    )),
+    ModelConfigEntry::new(
         DEEPSEEK_V4_FLASH_MODEL_ID,
         "DeepSeek V4 Flash",
         "DeepSeek V4 Flash",
@@ -897,6 +918,7 @@ mod tests {
         assert_eq!(model_context_window("glm-5-3-flash"), 1_048_576);
         assert_eq!(model_context_window("kimi-k3"), 262_144);
         assert_eq!(model_context_window("deepseek-v4-flash"), 1_048_576);
+        assert_eq!(model_context_window("deepseek-v4-1-flash"), 1_048_576);
         assert_eq!(model_context_window(AUTO_QUICK_MODEL_ID), 131_072);
         assert_eq!(model_context_window(AUTO_POWERFUL_MODEL_ID), 262_144);
     }
@@ -913,6 +935,7 @@ mod tests {
             "glm-5-3-flash",
             "kimi-k3",
             "deepseek-v4-flash",
+            "deepseek-v4-1-flash",
         ] {
             let config = model_config(model);
 
@@ -1040,6 +1063,10 @@ mod tests {
             resolve_completion_model_id("deepseek-v4-flash"),
             Some("deepseek-v4-flash")
         );
+        assert_eq!(
+            resolve_completion_model_id("deepseek-v4-1-flash"),
+            Some("deepseek-v4-1-flash")
+        );
         assert_eq!(resolve_completion_model_id("unknown-model"), None);
     }
 
@@ -1067,6 +1094,10 @@ mod tests {
         assert_eq!(
             resolve_public_model_id("deepseek-v4-flash"),
             Some("deepseek-v4-flash")
+        );
+        assert_eq!(
+            resolve_public_model_id("deepseek-v4-1-flash"),
+            Some("deepseek-v4-1-flash")
         );
         assert_eq!(resolve_public_model_id("unknown-model"), None);
     }
@@ -1303,6 +1334,7 @@ mod tests {
             "glm-5-3",
             "glm-5-3-flash",
             "deepseek-v4-flash",
+            "deepseek-v4-1-flash",
             AUTO_POWERFUL_MODEL_ID,
         ] {
             assert!(
@@ -1436,6 +1468,32 @@ mod tests {
     }
 
     #[test]
+    fn test_catalog_adds_deepseek_v4_1_flash_through_tinfoil_with_image_and_1m_context() {
+        let catalog = model_catalog_response(ModelAliasTargets::for_plan(ModelPlan::Paid));
+        let deepseek = catalog_model(&catalog, DEEPSEEK_V4_1_FLASH_MODEL_ID);
+
+        assert_eq!(deepseek["provider"], "tinfoil");
+        assert_eq!(deepseek["provider_id"], DEEPSEEK_V4_1_FLASH_MODEL_ID);
+        assert_eq!(deepseek["display_name"], "DeepSeek V4.1 Flash");
+        assert_eq!(deepseek["access"], "pro");
+        assert_eq!(deepseek["context_window"], 1_048_576);
+        assert_eq!(deepseek["input_modalities"], json!(["text", "image"]));
+        assert_eq!(deepseek["output_modalities"], json!(["text"]));
+        assert_eq!(deepseek["capabilities"]["vision"], true);
+        assert_eq!(deepseek["capabilities"]["reasoning"], true);
+        assert_eq!(deepseek["capabilities"]["tool_use"], true);
+        assert_eq!(deepseek["tasks"], json!(["generate", "vision"]));
+        assert_eq!(
+            resolve_completion_model_id(DEEPSEEK_V4_1_FLASH_MODEL_ID),
+            Some(DEEPSEEK_V4_1_FLASH_MODEL_ID)
+        );
+        assert_eq!(
+            catalog_model(&catalog, DEEPSEEK_V4_FLASH_MODEL_ID)["id"],
+            DEEPSEEK_V4_FLASH_MODEL_ID
+        );
+    }
+
+    #[test]
     fn test_new_tinfoil_models_are_generally_listed() {
         let catalog = model_catalog_response(ModelAliasTargets::default());
         let openai_models = openai_models_response();
@@ -1443,6 +1501,7 @@ mod tests {
         for model in [
             "kimi-k3",
             "deepseek-v4-flash",
+            "deepseek-v4-1-flash",
             GLM_5_3_FLASH_MODEL_ID,
             QUICK_MODEL_ID,
         ] {
@@ -1454,6 +1513,7 @@ mod tests {
     #[test]
     fn test_new_badges_match_the_currently_launched_models() {
         let expected = vec![
+            DEEPSEEK_V4_1_FLASH_MODEL_ID.to_string(),
             DEEPSEEK_V4_FLASH_MODEL_ID.to_string(),
             GLM_5_3_MODEL_ID.to_string(),
             GLM_5_3_FLASH_MODEL_ID.to_string(),
@@ -1498,6 +1558,20 @@ mod tests {
         assert_eq!(deepseek["capabilities"]["reasoning"], true);
         assert_eq!(deepseek["capabilities"]["tool_use"], true);
         assert_eq!(deepseek["tasks"], json!(["generate"]));
+
+        let deepseek_v41 = catalog_model(&catalog, DEEPSEEK_V4_1_FLASH_MODEL_ID);
+        assert_eq!(deepseek_v41["access"], "pro");
+        assert_eq!(deepseek_v41["provider_id"], DEEPSEEK_V4_1_FLASH_MODEL_ID);
+        assert_eq!(deepseek_v41["display_name"], "DeepSeek V4.1 Flash");
+        assert_eq!(deepseek_v41["context_window"], 1_048_576);
+        assert_eq!(deepseek_v41["input_modalities"], json!(["text", "image"]));
+        assert_eq!(deepseek_v41["output_modalities"], json!(["text"]));
+        assert_eq!(deepseek_v41["parameter_size"], "552B");
+        assert_eq!(deepseek_v41["active_parameter_size"], "16B");
+        assert_eq!(deepseek_v41["capabilities"]["vision"], true);
+        assert_eq!(deepseek_v41["capabilities"]["reasoning"], true);
+        assert_eq!(deepseek_v41["capabilities"]["tool_use"], true);
+        assert_eq!(deepseek_v41["tasks"], json!(["generate", "vision"]));
 
         let minimal = openai_models_response();
         let minimal_kimi = catalog_model(&minimal, "kimi-k3");

--- a/services/opensecret/src/provider_registry.rs
+++ b/services/opensecret/src/provider_registry.rs
@@ -6,8 +6,8 @@
 //! separate Router v1 configuration.
 
 use crate::model_config::{
-    DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_3_FLASH_MODEL_ID, GLM_5_3_MODEL_ID, KIMI_K2_6_MODEL_ID,
-    KIMI_K3_MODEL_ID, QUICK_MODEL_ID,
+    DEEPSEEK_V4_1_FLASH_MODEL_ID, DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_3_FLASH_MODEL_ID,
+    GLM_5_3_MODEL_ID, KIMI_K2_6_MODEL_ID, KIMI_K3_MODEL_ID, QUICK_MODEL_ID,
 };
 
 pub(crate) const SHADOW_ROUTING_POLICY_VERSION: &str = "routing-v2-weighted-v2";
@@ -182,6 +182,15 @@ const DEEPSEEK_V4_FLASH_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     enabled: true,
 }];
 
+const DEEPSEEK_V4_1_FLASH_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: DEEPSEEK_V4_1_FLASH_MODEL_ID,
+    response_model_id: DEEPSEEK_V4_1_FLASH_MODEL_ID,
+    rate_limit_scope: RateLimitScope::ProviderModel,
+    weight: 100,
+    enabled: true,
+}];
+
 const LLAMA3_3_70B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: "llama3-3-70b",
@@ -224,6 +233,10 @@ const COMPLETION_MODELS: &[CompletionModelSpec] = &[
     CompletionModelSpec {
         public_model_id: GLM_5_3_FLASH_MODEL_ID,
         routes: GLM_5_3_FLASH_ROUTES,
+    },
+    CompletionModelSpec {
+        public_model_id: DEEPSEEK_V4_1_FLASH_MODEL_ID,
+        routes: DEEPSEEK_V4_1_FLASH_ROUTES,
     },
     CompletionModelSpec {
         public_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
@@ -299,6 +312,7 @@ mod tests {
                 KIMI_K2_6_MODEL_ID,
                 GLM_5_3_MODEL_ID,
                 GLM_5_3_FLASH_MODEL_ID,
+                DEEPSEEK_V4_1_FLASH_MODEL_ID,
                 DEEPSEEK_V4_FLASH_MODEL_ID,
                 "llama3-3-70b",
                 "gpt-oss-safeguard-120b",
@@ -379,6 +393,12 @@ mod tests {
                     ProviderId::Tinfoil,
                     GLM_5_3_FLASH_MODEL_ID,
                     GLM_5_3_FLASH_MODEL_ID
+                ),
+                (
+                    DEEPSEEK_V4_1_FLASH_MODEL_ID,
+                    ProviderId::Tinfoil,
+                    DEEPSEEK_V4_1_FLASH_MODEL_ID,
+                    DEEPSEEK_V4_1_FLASH_MODEL_ID
                 ),
                 (
                     DEEPSEEK_V4_FLASH_MODEL_ID,

--- a/services/opensecret/src/provider_routing.rs
+++ b/services/opensecret/src/provider_routing.rs
@@ -1257,6 +1257,8 @@ mod tests {
             "kimi-k-3",
             "kimi-k3-latest",
             "deepseek-v4-flash-0731",
+            "deepseek-v4.1-flash",
+            "deepseek-v4-1-flash-latest",
         ] {
             let account_uuid = uuid_for_bucket(50);
             let intent = InferenceIntent::new(
@@ -1868,7 +1870,12 @@ mod tests {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
 
-        for model_id in ["kimi-k3", "deepseek-v4-flash", "glm-5-3-flash"] {
+        for model_id in [
+            "kimi-k3",
+            "deepseek-v4-flash",
+            "deepseek-v4-1-flash",
+            "glm-5-3-flash",
+        ] {
             let selected = router
                 .select_completion_route(&proxy_router, uuid_for_bucket(50), model_id)
                 .expect("canonical Tinfoil model should route");
@@ -1891,6 +1898,9 @@ mod tests {
             "kimi-k3-latest",
             "deepseek-v4-flash-0731",
             "deepseek-v4flash",
+            "deepseek-v4.1-flash",
+            "deepseek-v4-1-flash-latest",
+            "deepseek-v41-flash",
             "glm-5.3-flash",
             "glm-5-3-flash-latest",
         ] {

--- a/services/opensecret/src/tokens.rs
+++ b/services/opensecret/src/tokens.rs
@@ -55,6 +55,7 @@ mod tests {
         assert_eq!(model_max_ctx("glm-5-3-flash"), 1_048_576);
         assert_eq!(model_max_ctx("kimi-k3"), 262_144);
         assert_eq!(model_max_ctx("deepseek-v4-flash"), 1_048_576);
+        assert_eq!(model_max_ctx("deepseek-v4-1-flash"), 1_048_576);
         assert_eq!(model_max_ctx("auto:quick"), 131_072);
         assert_eq!(model_max_ctx("auto:powerful"), 262_144);
     }

--- a/services/opensecret/src/web/openai.rs
+++ b/services/opensecret/src/web/openai.rs
@@ -6098,6 +6098,11 @@ mod tests {
         ));
         assert!(ensure_completion_model_access("deepseek-v4-flash", ModelPlan::Paid).is_ok());
         assert!(matches!(
+            ensure_completion_model_access("deepseek-v4-1-flash", ModelPlan::Free),
+            Err(ApiError::ModelNotAvailableOnPlan)
+        ));
+        assert!(ensure_completion_model_access("deepseek-v4-1-flash", ModelPlan::Paid).is_ok());
+        assert!(matches!(
             ensure_completion_model_access("glm-5-3", ModelPlan::Free),
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
@@ -6665,6 +6670,7 @@ mod tests {
         for (provider, public_model) in [
             ("tinfoil", "gpt-oss-120b"),
             ("tinfoil", "deepseek-v4-flash"),
+            ("tinfoil", "deepseek-v4-1-flash"),
             ("tinfoil", "kimi-k3"),
             ("tinfoil", "glm-5-3"),
             ("tinfoil", "glm-5-3-flash"),

--- a/services/opensecret/src/web/responses/context_builder.rs
+++ b/services/opensecret/src/web/responses/context_builder.rs
@@ -1004,6 +1004,8 @@ mod tests {
         assert_eq!(prompt_token_budget("llama3-3-70b"), 131_072);
         assert_eq!(prompt_token_budget("glm-5-3"), 262_144);
         assert_eq!(prompt_token_budget("glm-5-3-flash"), 1_048_576);
+        assert_eq!(prompt_token_budget("deepseek-v4-1-flash"), 1_048_576);
+        assert_eq!(prompt_token_budget("deepseek-v4-flash"), 1_048_576);
     }
 
     // Helper to create a ChatMsg

--- a/services/opensecret/src/web/responses/handlers.rs
+++ b/services/opensecret/src/web/responses/handlers.rs
@@ -1804,6 +1804,14 @@ mod tests {
             resolve_responses_model("deepseek-v4-flash", "tinfoil", ModelPlan::Paid).unwrap(),
             "deepseek-v4-flash"
         );
+        assert!(matches!(
+            resolve_responses_model("deepseek-v4-1-flash", "tinfoil", ModelPlan::Free),
+            Err(ApiError::ModelNotAvailableOnPlan)
+        ));
+        assert_eq!(
+            resolve_responses_model("deepseek-v4-1-flash", "tinfoil", ModelPlan::Paid).unwrap(),
+            "deepseek-v4-1-flash"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add Tinfoil's `deepseek-v4-1-flash` as a generally listed Pro completion model. DeepSeek V4 Flash stays selectable and remains the paid Quick default.

## Changes

- catalog `deepseek-v4-1-flash` through Tinfoil with 1M context, vision, reasoning, and tool use
- register the Tinfoil route in router v2 with per-model rate-limit scope
- keep canonical ID pinning and reject near-spellings such as `deepseek-v4.1-flash`
- gate the model to paid plans on chat completions and Responses

## Validation

- OpenSecret `cargo test --locked --all-features`: 635 passed, 0 failed, 23 ignored
- Maple pre-commit: frontend Prettier, production build, and 818 bun tests

Not run: live Tinfoil probe, encrypted SDK or Maple smoke. Billing and marketing are separate PRs.
