### PR TITLE
Fail proxy CI immediately when a check fails

### DIFF
--- a/.agents/skills/develop-maple-proxy/SKILL.md
+++ b/.agents/skills/develop-maple-proxy/SKILL.md
@@ -37,6 +37,7 @@ Run the credential-free proxy checks through its pinned shell:
 
 ```sh
 nix develop --no-update-lock-file ./proxy -c bash -lc '
+  set -euo pipefail
   cd proxy
   cargo fmt --all -- --check
   cargo clippy --locked --all-targets --all-features -- -D warnings

--- a/.agents/skills/validate-maple/SKILL.md
+++ b/.agents/skills/validate-maple/SKILL.md
@@ -160,6 +160,7 @@ Run the proxy's CI-equivalent component checks through its pinned shell:
 
 ```bash
 nix develop --no-update-lock-file ./proxy -c bash -lc '
+  set -euo pipefail
   cd proxy
   cargo fmt --all -- --check
   cargo clippy --locked --all-targets --all-features -- -D warnings

--- a/.github/workflows/proxy-rust.yml
+++ b/.github/workflows/proxy-rust.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Run credential-free proxy checks
         run: |
           nix develop --no-update-lock-file ./proxy -c bash -lc '
+            set -euo pipefail
             cd proxy
             cargo fmt --all -- --check
             cargo clippy --locked --all-targets --all-features -- -D warnings


### PR DESCRIPTION
Proxy CI could report success after formatting, Clippy, tests, or documentation failed because its nested Bash block returned only the final `cargo machete` status. Enable `set -euo pipefail` before the checks so the first failure stops the job, and update the two matching validation examples.

Validation:
- Extracted the actual workflow shell block and injected a failure at each of the five Cargo commands: every failure now returns its nonzero status immediately; the successful path still runs all five commands. The original block reproduced the masked failures.
- `nix flake check --no-update-lock-file` passed on macOS ARM64, including workflow lint and release gates.
- Pre-commit formatting, TypeScript/Vite build, and all 818 frontend tests passed.
- Independent review and `git diff --check` passed. Full proxy builds are left to PR CI.
